### PR TITLE
[Phase 3] Video Streaming — SportSRC integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env.local

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "glory-glory",
       "version": "0.1.0",
       "dependencies": {
+        "@max-xoo/fotmob": "^2.5.1",
         "@types/better-sqlite3": "^7.6.13",
         "axios": "^1.14.0",
         "better-sqlite3": "^12.8.0",
+        "fotmob": "^2.4.1",
         "next": "16.2.2",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -1024,6 +1026,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@max-xoo/fotmob": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@max-xoo/fotmob/-/fotmob-2.5.1.tgz",
+      "integrity": "sha512-Q/MQGYorWrgY4oNLEp0bDQTJ8mQgE2V8aVnw3f18CmE4+MP0vuyo8G65yUCqH8YzuzNCtLl1M/+kkUQZWut14w==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.7.9"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1236,6 +1247,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1243,6 +1266,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -1536,11 +1571,29 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1556,6 +1609,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.39",
@@ -1584,6 +1646,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2608,6 +2679,33 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2715,6 +2813,27 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone-response/node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2893,6 +3012,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
@@ -3807,6 +3935,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fotmob": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/fotmob/-/fotmob-2.4.1.tgz",
+      "integrity": "sha512-12GAtffM+6H+bjUYASxO3HujWOYZcLg1YsBCIm/1lFkvmCRZyOXP8hB3yrmrr69AOqG5o1czZsvn+m5odadF1g==",
+      "license": "MIT",
+      "dependencies": {
+        "got": "11.8.5"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -3910,6 +4047,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -4000,6 +4152,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
       }
     },
     "node_modules/graceful-fs": {
@@ -4115,6 +4292,25 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/ieee754": {
@@ -4695,7 +4891,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -4745,7 +4940,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -5082,6 +5276,15 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5381,6 +5584,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5547,6 +5762,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -5778,6 +6002,18 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5912,6 +6148,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5930,6 +6172,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@max-xoo/fotmob": "^2.5.1",
     "@types/better-sqlite3": "^7.6.13",
     "axios": "^1.14.0",
     "better-sqlite3": "^12.8.0",
+    "fotmob": "^2.4.1",
     "next": "16.2.2",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -1,36 +1,96 @@
 import { NextResponse } from 'next/server';
-import { getPremierLeagueTable, getMatchDetails, getCurrentAndUpcomingMatch } from '@/lib/fotmob';
+import { getPremierLeagueTable, getMatchDetails as getFotMobMatch, getCurrentAndUpcomingMatch, getManUtdFixtures } from '@/lib/fotmob';
+import { getMatchDetail as getSportSrcDetail, getMatchesForDate } from '@/lib/sportsrc';
 
 export const revalidate = 60;
+
+// Cache for SportSRC match lookups
+const sportsrcIdCache = new Map<string, string>();
+
+async function findSportSrcId(fotmobMatchId: string, homeTeam: string, awayTeam: string, utcTime: string): Promise<string | null> {
+  // Check cache first
+  if (sportsrcIdCache.has(fotmobMatchId)) {
+    return sportsrcIdCache.get(fotmobMatchId) || null;
+  }
+  
+  // Extract date from UTC time
+  const date = utcTime.split('T')[0];
+  
+  try {
+    const matches = await getMatchesForDate(date);
+    
+    // Find matching match by team names
+    const match = matches.find(m => {
+      const homeMatch = m.home.toLowerCase().includes('manchester') && m.home.toLowerCase().includes('united');
+      const awayMatch = m.away.toLowerCase().includes('manchester') && m.away.toLowerCase().includes('united');
+      const homeAlso = m.home.toLowerCase().includes('united') || m.home.toLowerCase().includes('manchester');
+      const awayAlso = m.away.toLowerCase().includes('united') || m.away.toLowerCase().includes('manchester');
+      
+      return (homeMatch || awayMatch) &&
+             (m.home.toLowerCase().includes(homeTeam.toLowerCase().split(' ')[0]) ||
+              m.away.toLowerCase().includes(awayTeam.toLowerCase().split(' ')[0]));
+    });
+    
+    if (match) {
+      sportsrcIdCache.set(fotmobMatchId, match.id);
+      return match.id;
+    }
+  } catch (e) {
+    console.error('Failed to find SportSrc ID:', e);
+  }
+  
+  return null;
+}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const matchId = searchParams.get('matchId');
-  const fixturesOnly = searchParams.get('fixturesOnly') === 'true';
+  const sportsrcId = searchParams.get('sportsrcId');
   
   try {
-    // If specific match requested, return detailed data
+    // If SportSRC ID provided, return stream info
+    if (sportsrcId) {
+      const stream = await getSportSrcDetail(sportsrcId);
+      return NextResponse.json({ stream });
+    }
+    
+    // If specific FotMob match ID, return detailed match data + stream
     if (matchId) {
-      const match = await getMatchDetails(parseInt(matchId));
+      const numMatchId = parseInt(matchId);
+      const match = await getFotMobMatch(numMatchId);
+      
       if (!match) {
         return NextResponse.json({ error: 'Match not found' }, { status: 404 });
       }
-      return NextResponse.json({ match });
+      
+      // Try to find stream
+      let stream = null;
+      let sportSrcId = null;
+      
+      try {
+        sportSrcId = await findSportSrcId(
+          matchId,
+          match.homeTeam.name,
+          match.awayTeam.name,
+          match.status.utcTime
+        );
+        
+        if (sportSrcId) {
+          stream = await getSportSrcDetail(sportSrcId);
+        }
+      } catch (e) {
+        console.error('Stream lookup failed:', e);
+      }
+      
+      return NextResponse.json({ match, stream, sportSrcId });
     }
     
-    // If fixtures only, just return fixture list
-    if (fixturesOnly) {
-      const { current, next, last } = await getCurrentAndUpcomingMatch();
-      return NextResponse.json({ current, next, last });
-    }
-    
-    // Otherwise return current/upcoming/last match + league table
+    // Return fixture list + table
     const [{ current, next, last }, table] = await Promise.all([
       getCurrentAndUpcomingMatch().catch(() => ({ current: null, next: null, last: null })),
       getPremierLeagueTable().catch(() => null),
     ]);
 
-    // Find Man Utd position in table
     const manUtdEntry = table?.all.find(t => t.id === '10260');
     
     return NextResponse.json({
@@ -43,7 +103,7 @@ export async function GET(request: Request) {
   } catch (error) {
     console.error('Matches API error:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch data', current: null, next: null, last: null, table: null },
+      { error: 'Failed to fetch data' },
       { status: 500 }
     );
   }

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -1,37 +1,40 @@
 import { NextResponse } from 'next/server';
+import { getPremierLeagueTable, getCurrentMatch, getMatchDetails } from '@/lib/fotmob';
 
-const SPORTSRC_BASE = 'https://api.sportsrc.org/v2';
+export const revalidate = 60; // Cache for 60 seconds
 
-export async function GET() {
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const matchId = searchParams.get('matchId');
+  
   try {
-    const response = await fetch(`${SPORTSRC_BASE}/scores`, {
-      next: { revalidate: 30 }, // Cache for 30 seconds
+    // If specific match requested, return that
+    if (matchId) {
+      const match = await getMatchDetails(parseInt(matchId));
+      if (!match) {
+        return NextResponse.json({ error: 'Match not found' }, { status: 404 });
+      }
+      return NextResponse.json({ match });
+    }
+    
+    // Otherwise return current Man Utd match + league table
+    const [currentMatch, table] = await Promise.all([
+      getCurrentMatch().catch(() => null),
+      getPremierLeagueTable().catch(() => null),
+    ]);
+
+    // Find Man Utd position in table
+    const manUtdEntry = table?.all.find(t => t.id === 10260);
+    
+    return NextResponse.json({
+      match: currentMatch,
+      table: manUtdEntry,
+      fullTable: table,
     });
-
-    if (!response.ok) {
-      throw new Error(`SportSRC API error: ${response.status}`);
-    }
-
-    const data = await response.json();
-    const matches = data.data || data;
-
-    // Filter for Man Utd
-    const manUtdMatch = matches.find((m: any) =>
-      m.home_team?.toLowerCase().includes('manchester united') ||
-      m.away_team?.toLowerCase().includes('manchester united') ||
-      m.home_team?.toLowerCase().includes('man utd') ||
-      m.away_team?.toLowerCase().includes('man utd')
-    );
-
-    if (!manUtdMatch) {
-      return NextResponse.json({ match: null, message: 'No Man Utd match found' });
-    }
-
-    return NextResponse.json({ match: manUtdMatch });
   } catch (error) {
     console.error('Matches API error:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch match data', match: null },
+      { error: 'Failed to fetch match data', match: null, table: null },
       { status: 500 }
     );
   }

--- a/src/app/api/matches/route.ts
+++ b/src/app/api/matches/route.ts
@@ -1,14 +1,15 @@
 import { NextResponse } from 'next/server';
-import { getPremierLeagueTable, getCurrentMatch, getMatchDetails } from '@/lib/fotmob';
+import { getPremierLeagueTable, getMatchDetails, getCurrentAndUpcomingMatch } from '@/lib/fotmob';
 
-export const revalidate = 60; // Cache for 60 seconds
+export const revalidate = 60;
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const matchId = searchParams.get('matchId');
+  const fixturesOnly = searchParams.get('fixturesOnly') === 'true';
   
   try {
-    // If specific match requested, return that
+    // If specific match requested, return detailed data
     if (matchId) {
       const match = await getMatchDetails(parseInt(matchId));
       if (!match) {
@@ -17,24 +18,32 @@ export async function GET(request: Request) {
       return NextResponse.json({ match });
     }
     
-    // Otherwise return current Man Utd match + league table
-    const [currentMatch, table] = await Promise.all([
-      getCurrentMatch().catch(() => null),
+    // If fixtures only, just return fixture list
+    if (fixturesOnly) {
+      const { current, next, last } = await getCurrentAndUpcomingMatch();
+      return NextResponse.json({ current, next, last });
+    }
+    
+    // Otherwise return current/upcoming/last match + league table
+    const [{ current, next, last }, table] = await Promise.all([
+      getCurrentAndUpcomingMatch().catch(() => ({ current: null, next: null, last: null })),
       getPremierLeagueTable().catch(() => null),
     ]);
 
     // Find Man Utd position in table
-    const manUtdEntry = table?.all.find(t => t.id === 10260);
+    const manUtdEntry = table?.all.find(t => t.id === '10260');
     
     return NextResponse.json({
-      match: currentMatch,
+      current,
+      next,
+      last,
       table: manUtdEntry,
       fullTable: table,
     });
   } catch (error) {
     console.error('Matches API error:', error);
     return NextResponse.json(
-      { error: 'Failed to fetch match data', match: null, table: null },
+      { error: 'Failed to fetch data', current: null, next: null, last: null, table: null },
       { status: 500 }
     );
   }

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -64,7 +64,7 @@ export default function ChatPage() {
             className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
           >
             <div
-              className={`max-w-[80%] rounded-xl px-4 py-3 ${
+              className={`max-w-[80%] border px-4 py-3 ${
                 msg.role === 'user'
                   ? 'bg-[#DA291C] text-white'
                   : 'bg-white/10 text-white'
@@ -78,11 +78,11 @@ export default function ChatPage() {
         ))}
         {loading && (
           <div className="flex justify-start">
-            <div className="bg-white/10 rounded-xl px-4 py-3">
+            <div className="bg-white/10 border px-4 py-3">
               <div className="flex gap-1">
-                <div className="w-2 h-2 bg-white/50 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-                <div className="w-2 h-2 bg-white/50 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-                <div className="w-2 h-2 bg-white/50 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+                <div className="w-2 h-2 bg-white/50 border animate-bounce" style={{ animationDelay: '0ms' }} />
+                <div className="w-2 h-2 bg-white/50 border animate-bounce" style={{ animationDelay: '150ms' }} />
+                <div className="w-2 h-2 bg-white/50 border animate-bounce" style={{ animationDelay: '300ms' }} />
               </div>
             </div>
           </div>
@@ -121,7 +121,7 @@ export default function ChatPage() {
             <button
               key={example}
               onClick={() => setInput(example)}
-              className="text-sm bg-white/5 hover:bg-white/10 px-3 py-1 rounded-full transition-colors"
+              className="text-sm bg-white/5 hover:bg-white/10 px-3 py-1 border transition-colors"
             >
               {example}
             </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,7 +22,8 @@ body {
 }
 
 body {
-  background: linear-gradient(180deg, #0B0523 0%, #120a2e 100%);
+  background: #0B0523;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
 a {
@@ -30,74 +31,34 @@ a {
   text-decoration: none;
 }
 
-.card {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 12px;
-  padding: 1.5rem;
+/* Custom scrollbar */
+::-webkit-scrollbar {
+  width: 6px;
 }
 
-.btn-primary {
-  background-color: #DA291C;
-  color: white;
-  padding: 0.75rem 1.5rem;
-  border-radius: 8px;
-  font-weight: 600;
-  border: none;
-  cursor: pointer;
-  transition: all 0.2s;
+::-webkit-scrollbar-track {
+  background: transparent;
 }
 
-.btn-primary:hover {
-  background-color: #b71c1c;
-  transform: translateY(-1px);
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
 }
 
-.btn-secondary {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: white;
-  padding: 0.75rem 1.5rem;
-  border-radius: 8px;
-  font-weight: 600;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  cursor: pointer;
-  transition: all 0.2s;
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.3);
 }
 
-.btn-secondary:hover {
-  background-color: rgba(255, 255, 255, 0.15);
+/* Transitions */
+.transition-colors {
+  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
 }
 
-input, textarea {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
-  color: white;
-  width: 100%;
+/* Animations */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(4px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
-input:focus, textarea:focus {
-  outline: none;
-  border-color: #DA291C;
-}
-
-.tag {
-  display: inline-block;
-  background: rgba(218, 41, 28, 0.2);
-  color: #DA291C;
-  padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-}
-
-.scrollbar-hide::-webkit-scrollbar {
-  display: none;
-}
-
-.scrollbar-hide {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+.animate-fade-in {
+  animation: fadeIn 0.3s ease forwards;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,8 +4,9 @@
 
 :root {
   --united-red: #DA291C;
-  --united-dark: #0B0523;
   --united-light: #FBE122;
+  --bg: #0a0a0a;
+  --surface: #111111;
 }
 
 * {
@@ -16,14 +17,16 @@ html,
 body {
   margin: 0;
   padding: 0;
-  background-color: #0B0523;
+  background-color: var(--bg);
   color: #ffffff;
   min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 body {
-  background: #0B0523;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
 }
 
 a {
@@ -31,9 +34,10 @@ a {
   text-decoration: none;
 }
 
-/* Custom scrollbar */
+/* Scrollbar */
 ::-webkit-scrollbar {
-  width: 6px;
+  width: 4px;
+  height: 4px;
 }
 
 ::-webkit-scrollbar-track {
@@ -41,24 +45,31 @@ a {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.15);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.25);
 }
 
-/* Transitions */
-.transition-colors {
-  transition: color 0.15s ease, background-color 0.15s ease, border-color 0.15s ease;
+/* Utility: sharp borders */
+.border-sharp {
+  border-radius: 2px;
 }
 
-/* Animations */
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(4px); }
-  to { opacity: 1; transform: translateY(0); }
+/* Page transitions */
+.page-enter {
+  opacity: 0;
+  transform: translateY(4px);
 }
 
-.animate-fade-in {
-  animation: fadeIn 0.3s ease forwards;
+.page-enter-active {
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+/* Tab underline indicator */
+.tab-active {
+  border-bottom: 2px solid var(--united-red);
 }

--- a/src/app/goals/[id]/page.tsx
+++ b/src/app/goals/[id]/page.tsx
@@ -36,7 +36,7 @@ export default function GoalDetailPage({ params }: { params: Promise<{ id: strin
 
       {/* Video */}
       {goal.youtube_url && (
-        <div className="aspect-video bg-black rounded-xl overflow-hidden">
+        <div className="aspect-video bg-black border overflow-hidden">
           <iframe
             src={goal.youtube_url.replace('watch?v=', 'embed/')}
             className="w-full h-full"

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -27,19 +27,19 @@ export default function GoalsPage() {
     <div className="space-y-8">
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
-          <h1 className="text-4xl font-bold">Goals Archive</h1>
+          <h1 className="text-2xl font-bold tracking-tight">Goals Archive</h1>
           <p className="text-white/50 mt-1">{filteredGoals.filter(g => g.scorer).length} goals this season</p>
         </div>
         <div className="flex gap-2">
           <button
             onClick={() => setView('table')}
-            className={`px-4 py-2 rounded-lg font-medium transition-colors ${view === 'table' ? 'bg-[#DA291C] text-white' : 'bg-white/10 text-white/70'}`}
+            className={`px-4 py-2  font-medium transition-colors ${view === 'table' ? 'bg-[#DA291C] text-white' : 'bg-white/10 text-white/70'}`}
           >
             Table
           </button>
           <button
             onClick={() => setView('gallery')}
-            className={`px-4 py-2 rounded-lg font-medium transition-colors ${view === 'gallery' ? 'bg-[#DA291C] text-white' : 'bg-white/10 text-white/70'}`}
+            className={`px-4 py-2  font-medium transition-colors ${view === 'gallery' ? 'bg-[#DA291C] text-white' : 'bg-white/10 text-white/70'}`}
           >
             Gallery
           </button>
@@ -51,7 +51,7 @@ export default function GoalsPage() {
         <select
           value={scorerFilter}
           onChange={(e) => setScorerFilter(e.target.value)}
-          className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white"
+          className="bg-white/10 border border-white/20  px-4 py-2 text-white"
         >
           <option value="">All Scorers</option>
           {scorers.map(s => (
@@ -61,7 +61,7 @@ export default function GoalsPage() {
         <select
           value={typeFilter}
           onChange={(e) => setTypeFilter(e.target.value)}
-          className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white"
+          className="bg-white/10 border border-white/20  px-4 py-2 text-white"
         >
           <option value="">All Types</option>
           {goalTypes.map(t => (
@@ -71,7 +71,7 @@ export default function GoalsPage() {
         <select
           value={tagFilter}
           onChange={(e) => setTagFilter(e.target.value)}
-          className="bg-white/10 border border-white/20 rounded-lg px-4 py-2 text-white"
+          className="bg-white/10 border border-white/20  px-4 py-2 text-white"
         >
           <option value="">All Tags</option>
           {tags.map(t => (
@@ -140,7 +140,7 @@ export default function GoalsPage() {
             <Link
               key={goal.id}
               href={`/goals/${goal.id}`}
-              className="card hover:border-[#DA291C] transition-all group"
+              className="border border-white/10 hover:border-[#DA291C] transition-all group"
             >
               <div className="flex items-start justify-between mb-3">
                 <div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,8 +13,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="min-h-full antialiased">
-        <div className="max-w-2xl mx-auto px-6 py-8">
+      <body className="min-h-full antialiased bg-[#0a0a0a]">
+        <div className="max-w-[640px] mx-auto px-5 py-8">
           {children}
         </div>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
-  title: "Glory Glory - Man Utd AI Match Companion",
-  description: "The smartest person in the pub, in your pocket. AI-powered Manchester United match companion.",
+  title: "Glory Glory — Man United",
+  description: "AI-powered match companion for Manchester United fans",
 };
 
 export default function RootLayout({
@@ -13,32 +13,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="min-h-screen flex flex-col">
-        <nav className="sticky top-0 z-50 bg-[#0B0523]/90 backdrop-blur-md border-b border-white/10">
-          <div className="max-w-7xl mx-auto px-4 py-4">
-            <div className="flex items-center justify-between">
-              <a href="/" className="flex items-center gap-3">
-                <div className="w-10 h-10 bg-[#DA291C] rounded-lg flex items-center justify-center font-bold text-xl">
-                  GG
-                </div>
-                <span className="text-xl font-bold tracking-tight">Glory Glory</span>
-              </a>
-              <div className="flex gap-6">
-                <a href="/goals" className="hover:text-[#DA291C] transition-colors font-medium">Goals</a>
-                <a href="/matches" className="hover:text-[#DA291C] transition-colors font-medium">Match</a>
-                <a href="/chat" className="hover:text-[#DA291C] transition-colors font-medium">Chat</a>
-              </div>
-            </div>
-          </div>
-        </nav>
-        <main className="max-w-7xl mx-auto px-4 py-8 flex-1 w-full">
+      <body className="min-h-full antialiased">
+        <div className="max-w-2xl mx-auto px-6 py-8">
           {children}
-        </main>
-        <footer className="border-t border-white/10 mt-16 py-8">
-          <div className="max-w-7xl mx-auto px-4 text-center text-white/50 text-sm">
-            Glory Glory — For the fans, by the fans. GGMU.
-          </div>
-        </footer>
+        </div>
       </body>
     </html>
   );

--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -43,12 +43,10 @@ export default function MatchDetailPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="flex gap-1">
-          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
-        </div>
+      <div className="flex items-center gap-1.5 py-16">
+        <div className="w-1 h-1 bg-white/40 rounded-full animate-pulse" />
+        <div className="w-1 h-1 bg-white/40 rounded-full animate-pulse" style={{ animationDelay: '150ms' }} />
+        <div className="w-1 h-1 bg-white/40 rounded-full animate-pulse" style={{ animationDelay: '300ms' }} />
       </div>
     );
   }
@@ -56,11 +54,11 @@ export default function MatchDetailPage() {
   if (error || !match) {
     return (
       <div className="space-y-6">
-        <Link href="/matches" className="text-sm text-white/40 hover:text-white">
+        <Link href="/matches" className="text-xs text-white/40 hover:text-white/70">
           ← Back to Matches
         </Link>
-        <div className="border border-white/10 p-8 text-center">
-          <p className="text-white/50">{error || 'Match not found'}</p>
+        <div className="border border-white/10 px-5 py-8 text-center">
+          <p className="text-sm text-white/40">{error || 'Match not found'}</p>
         </div>
       </div>
     );
@@ -78,90 +76,90 @@ export default function MatchDetailPage() {
   const displayAway = isManUtdHome ? match.awayTeam : match.homeTeam;
   const displayHomeScore = isManUtdHome ? match.homeScore : match.awayScore;
   const displayAwayScore = isManUtdHome ? match.awayScore : match.homeScore;
-
-  // Get team ID for shot map
   const shotsTeamId = isManUtdHome ? match.homeTeam.id : match.awayTeam.id;
 
   return (
     <div className="space-y-6">
-      {/* Back link */}
-      <Link href="/matches" className="text-sm text-white/40 hover:text-white">
+      {/* Back */}
+      <Link href="/matches" className="text-xs text-white/40 hover:text-white/70">
         ← Back
       </Link>
 
       {/* Match Header */}
       <div className="border border-white/10">
-        <div className="p-6">
+        {/* Score */}
+        <div className="px-5 py-5">
           <div className="flex items-center justify-between">
             <div className="flex-1">
-              <p className="text-lg font-semibold">{displayHome.name}</p>
-              <p className="text-4xl font-mono font-bold mt-1">{displayHomeScore}</p>
+              <p className="text-sm font-medium text-white/60">{displayHome.name}</p>
+              <p className="text-[2.5rem] font-mono font-bold leading-none mt-1">{displayHomeScore}</p>
             </div>
-            <div className="text-center px-6">
-              <span className="text-xs font-medium px-2 py-1 bg-white/10 text-white/70">
+            <div className="text-center px-4">
+              <p className="text-[10px] text-white/30 leading-tight">
                 {match.status.scoreStr || ''}
-              </span>
-              {match.status.utcTime && (
-                <p className="text-sm text-white/40 mt-2">
-                  {new Date(match.status.utcTime).toLocaleDateString('en-GB', {
-                    day: 'numeric',
-                    month: 'short',
-                    year: 'numeric',
-                  })}
-                </p>
-              )}
+                {match.status.utcTime && (
+                  <>
+                    <br />
+                    {new Date(match.status.utcTime).toLocaleDateString('en-GB', {
+                      day: 'numeric', month: 'short',
+                    })}
+                  </>
+                )}
+              </p>
             </div>
             <div className="flex-1 text-right">
-              <p className="text-lg font-semibold">{displayAway.name}</p>
-              <p className="text-4xl font-mono font-bold mt-1">{displayAwayScore}</p>
+              <p className="text-sm font-medium text-white/60">{displayAway.name}</p>
+              <p className="text-[2.5rem] font-mono font-bold leading-none mt-1">{displayAwayScore}</p>
             </div>
           </div>
         </div>
 
-        {/* xG bar */}
+        {/* xG */}
         {match.stats.xg && (
-          <div className="border-t border-white/10 px-6 py-3">
+          <div className="border-t border-white/8 px-5 py-3">
             <div className="flex items-center gap-3">
-              <span className="text-xs text-white/40 w-12">{match.stats.xg.home.toFixed(2)} xG</span>
-              <div className="flex-1 flex h-1 rounded-sm overflow-hidden">
+              <span className="text-[11px] text-white/35 w-10 text-right font-mono">
+                {match.stats.xg.home.toFixed(2)}
+              </span>
+              <div className="flex-1 flex h-[3px]">
                 <div
                   className="bg-[#DA291C]"
                   style={{
                     width: `${(match.stats.xg!.home / (match.stats.xg!.home + match.stats.xg!.away)) * 100}%`,
                   }}
                 />
-                <div className="bg-white/20 flex-1" />
+                <div className="bg-white/10 flex-1" />
               </div>
-              <span className="text-xs text-white/40 w-12 text-right">{match.stats.xg.away.toFixed(2)} xG</span>
+              <span className="text-[11px] text-white/35 w-10 font-mono">
+                {match.stats.xg.away.toFixed(2)}
+              </span>
             </div>
+            <p className="text-[9px] text-white/20 text-center mt-1 uppercase tracking-wider">xG</p>
           </div>
         )}
 
         {/* Tabs */}
-        <div className="border-t border-white/10">
-          <div className="flex">
-            {tabs.map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={`flex-1 py-3 text-sm font-medium transition-colors border-b-2 ${
-                  activeTab === tab.id
-                    ? 'border-[#DA291C] text-white'
-                    : 'border-transparent text-white/40 hover:text-white/70'
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
-          </div>
+        <div className="border-t border-white/8 flex">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`flex-1 py-3 text-[13px] font-medium transition-colors border-b-2 ${
+                activeTab === tab.id
+                  ? 'border-[#DA291C] text-white'
+                  : 'border-transparent text-white/35 hover:text-white/60'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
         </div>
 
-        {/* Tab Content */}
-        <div className="p-6">
+        {/* Content */}
+        <div className="px-5 py-5">
           {activeTab === 'events' && (
             <EventTimeline events={match.events} homeTeamId={homeTeamId} />
           )}
-          
           {activeTab === 'stats' && (
             <MatchStats
               stats={match.stats}
@@ -169,7 +167,6 @@ export default function MatchDetailPage() {
               awayTeamName={match.awayTeam.name}
             />
           )}
-          
           {activeTab === 'shots' && (
             <ShotMap shots={match.shots} homeTeamId={shotsTeamId} />
           )}

--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -7,14 +7,16 @@ import ShotMap from '@/components/ShotMap';
 import EventTimeline from '@/components/EventTimeline';
 import MatchStats from '@/components/MatchStats';
 import { MatchDetails } from '@/lib/fotmob';
+import { MatchDetail as SportSrcMatch } from '@/lib/sportsrc';
 
-type Tab = 'events' | 'stats' | 'shots';
+type Tab = 'events' | 'stats' | 'shots' | 'watch';
 
 export default function MatchDetailPage() {
   const params = useParams();
   const matchId = params.id as string;
   
   const [match, setMatch] = useState<MatchDetails | null>(null);
+  const [stream, setStream] = useState<SportSrcMatch | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>('events');
@@ -22,12 +24,14 @@ export default function MatchDetailPage() {
   useEffect(() => {
     if (!matchId) return;
     
-    async function fetchMatch() {
+    async function fetchData() {
       try {
-        const response = await fetch(`/api/matches?matchId=${matchId}`);
-        const data = await response.json();
+        const res = await fetch(`/api/matches?matchId=${matchId}`);
+        const data = await res.json();
+        
         if (data.match) {
           setMatch(data.match);
+          setStream(data.stream || null);
         } else {
           setError('Match not found');
         }
@@ -38,7 +42,7 @@ export default function MatchDetailPage() {
       }
     }
     
-    fetchMatch();
+    fetchData();
   }, [matchId]);
 
   if (loading) {
@@ -68,6 +72,7 @@ export default function MatchDetailPage() {
     { id: 'events', label: 'Events' },
     { id: 'stats', label: 'Stats' },
     { id: 'shots', label: 'Shot Map' },
+    { id: 'watch', label: 'Watch' },
   ];
 
   const homeTeamId = match.homeTeam.id;
@@ -77,6 +82,9 @@ export default function MatchDetailPage() {
   const displayHomeScore = isManUtdHome ? match.homeScore : match.awayScore;
   const displayAwayScore = isManUtdHome ? match.awayScore : match.homeScore;
   const shotsTeamId = isManUtdHome ? match.homeTeam.id : match.awayTeam.id;
+
+  const hasStream = stream?.sources && stream.sources.length > 0;
+  const embedUrl = stream?.sources?.[0]?.embedUrl;
 
   return (
     <div className="space-y-6">
@@ -151,6 +159,9 @@ export default function MatchDetailPage() {
               }`}
             >
               {tab.label}
+              {tab.id === 'watch' && hasStream && (
+                <span className="ml-1.5 w-1.5 h-1.5 bg-[#DA291C] inline-block rounded-full" />
+              )}
             </button>
           ))}
         </div>
@@ -170,8 +181,77 @@ export default function MatchDetailPage() {
           {activeTab === 'shots' && (
             <ShotMap shots={match.shots} homeTeamId={shotsTeamId} />
           )}
+          {activeTab === 'watch' && (
+            <WatchTab stream={stream} />
+          )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function WatchTab({ stream }: { stream: SportSrcMatch | null }) {
+  const hasStream = stream?.sources && stream.sources.length > 0;
+  const embedUrl = stream?.sources?.[0]?.embedUrl;
+  
+  if (!hasStream || !embedUrl) {
+    return (
+      <div className="space-y-4">
+        <div className="border border-white/10 px-5 py-8 text-center">
+          <p className="text-sm text-white/50">Stream not yet available</p>
+          <p className="text-xs text-white/30 mt-1">
+            Streams are typically available closer to kickoff
+          </p>
+        </div>
+        <div className="text-center">
+          <a
+            href={`https://sport99.live`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-[#DA291C] hover:underline"
+          >
+            Watch on SportSRC →
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Source info */}
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-xs text-white/50">
+            {stream.sources[0].title || stream.sources[0].source}
+            {stream.sources[0].hd && <span className="ml-2 text-[#DA291C]">HD</span>}
+          </p>
+        </div>
+        <a
+          href={`https://sport99.live`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-white/30 hover:text-white/60"
+        >
+          SportSRC →
+        </a>
+      </div>
+      
+      {/* Stream embed */}
+      <div className="relative w-full" style={{ paddingTop: '56.25%' }}>
+        <iframe
+          src={embedUrl}
+          className="absolute inset-0 w-full h-full border-0"
+          allowFullScreen
+          allow="autoplay; fullscreen"
+          scrolling="no"
+        />
+      </div>
+      
+      {/* Disclaimer */}
+      <p className="text-[10px] text-white/20 text-center">
+        Stream provided by SportSRC. External content.
+      </p>
     </div>
   );
 }

--- a/src/app/matches/[id]/page.tsx
+++ b/src/app/matches/[id]/page.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import ShotMap from '@/components/ShotMap';
+import EventTimeline from '@/components/EventTimeline';
+import MatchStats from '@/components/MatchStats';
+import { MatchDetails } from '@/lib/fotmob';
+
+type Tab = 'events' | 'stats' | 'shots';
+
+export default function MatchDetailPage() {
+  const params = useParams();
+  const matchId = params.id as string;
+  
+  const [match, setMatch] = useState<MatchDetails | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<Tab>('events');
+
+  useEffect(() => {
+    if (!matchId) return;
+    
+    async function fetchMatch() {
+      try {
+        const response = await fetch(`/api/matches?matchId=${matchId}`);
+        const data = await response.json();
+        if (data.match) {
+          setMatch(data.match);
+        } else {
+          setError('Match not found');
+        }
+      } catch (err) {
+        setError('Failed to load match');
+      } finally {
+        setLoading(false);
+      }
+    }
+    
+    fetchMatch();
+  }, [matchId]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="flex gap-1">
+          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !match) {
+    return (
+      <div className="space-y-6">
+        <Link href="/matches" className="text-sm text-white/40 hover:text-white">
+          ← Back to Matches
+        </Link>
+        <div className="border border-white/10 p-8 text-center">
+          <p className="text-white/50">{error || 'Match not found'}</p>
+        </div>
+      </div>
+    );
+  }
+
+  const tabs: { id: Tab; label: string }[] = [
+    { id: 'events', label: 'Events' },
+    { id: 'stats', label: 'Stats' },
+    { id: 'shots', label: 'Shot Map' },
+  ];
+
+  const homeTeamId = match.homeTeam.id;
+  const isManUtdHome = String(homeTeamId) === '10260';
+  const displayHome = isManUtdHome ? match.homeTeam : match.awayTeam;
+  const displayAway = isManUtdHome ? match.awayTeam : match.homeTeam;
+  const displayHomeScore = isManUtdHome ? match.homeScore : match.awayScore;
+  const displayAwayScore = isManUtdHome ? match.awayScore : match.homeScore;
+
+  // Get team ID for shot map
+  const shotsTeamId = isManUtdHome ? match.homeTeam.id : match.awayTeam.id;
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Link href="/matches" className="text-sm text-white/40 hover:text-white">
+        ← Back
+      </Link>
+
+      {/* Match Header */}
+      <div className="border border-white/10">
+        <div className="p-6">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <p className="text-lg font-semibold">{displayHome.name}</p>
+              <p className="text-4xl font-mono font-bold mt-1">{displayHomeScore}</p>
+            </div>
+            <div className="text-center px-6">
+              <span className="text-xs font-medium px-2 py-1 bg-white/10 text-white/70">
+                {match.status.scoreStr || ''}
+              </span>
+              {match.status.utcTime && (
+                <p className="text-sm text-white/40 mt-2">
+                  {new Date(match.status.utcTime).toLocaleDateString('en-GB', {
+                    day: 'numeric',
+                    month: 'short',
+                    year: 'numeric',
+                  })}
+                </p>
+              )}
+            </div>
+            <div className="flex-1 text-right">
+              <p className="text-lg font-semibold">{displayAway.name}</p>
+              <p className="text-4xl font-mono font-bold mt-1">{displayAwayScore}</p>
+            </div>
+          </div>
+        </div>
+
+        {/* xG bar */}
+        {match.stats.xg && (
+          <div className="border-t border-white/10 px-6 py-3">
+            <div className="flex items-center gap-3">
+              <span className="text-xs text-white/40 w-12">{match.stats.xg.home.toFixed(2)} xG</span>
+              <div className="flex-1 flex h-1 rounded-sm overflow-hidden">
+                <div
+                  className="bg-[#DA291C]"
+                  style={{
+                    width: `${(match.stats.xg!.home / (match.stats.xg!.home + match.stats.xg!.away)) * 100}%`,
+                  }}
+                />
+                <div className="bg-white/20 flex-1" />
+              </div>
+              <span className="text-xs text-white/40 w-12 text-right">{match.stats.xg.away.toFixed(2)} xG</span>
+            </div>
+          </div>
+        )}
+
+        {/* Tabs */}
+        <div className="border-t border-white/10">
+          <div className="flex">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`flex-1 py-3 text-sm font-medium transition-colors border-b-2 ${
+                  activeTab === tab.id
+                    ? 'border-[#DA291C] text-white'
+                    : 'border-transparent text-white/40 hover:text-white/70'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Tab Content */}
+        <div className="p-6">
+          {activeTab === 'events' && (
+            <EventTimeline events={match.events} homeTeamId={homeTeamId} />
+          )}
+          
+          {activeTab === 'stats' && (
+            <MatchStats
+              stats={match.stats}
+              homeTeamName={match.homeTeam.name}
+              awayTeamName={match.awayTeam.name}
+            />
+          )}
+          
+          {activeTab === 'shots' && (
+            <ShotMap shots={match.shots} homeTeamId={shotsTeamId} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/matches/page.tsx
+++ b/src/app/matches/page.tsx
@@ -2,64 +2,54 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { FixtureMatch, LeagueTableEntry } from '@/lib/fotmob';
 
-interface MatchEvent {
-  id: string;
-  time: number;
-  type: string;
-  team: 'home' | 'away';
-  player?: string;
-  assist?: string;
-  detail?: string;
+interface MatchResponse {
+  current: FixtureMatch | null;
+  next: FixtureMatch | null;
+  last: FixtureMatch | null;
+  table: LeagueTableEntry | null;
+  fullTable: { all: LeagueTableEntry[] } | null;
 }
 
-interface Match {
-  matchId: number;
-  status: string;
-  homeTeam: { name: string; shortName: string };
-  awayTeam: { name: string; shortName: string };
-  homeScore: number;
-  awayScore: number;
-  datetime: string;
-  league: string;
-  events: MatchEvent[];
+function isManUtdHome(match: FixtureMatch): boolean {
+  return match.home.id === '10260';
 }
 
-interface TableEntry {
-  name: string;
-  shortName: string;
-  id: number;
-  played: number;
-  wins: number;
-  draws: number;
-  losses: number;
-  scoresStr: string;
-  goalConDiff: number;
-  pts: number;
-  idx: number;
+function getMatchDisplay(match: FixtureMatch) {
+  const isHome = isManUtdHome(match);
+  const scoreParts = (match.status.scoreStr || '').split(' - ');
+  return {
+    home: isHome ? 'Man United' : match.away.name,
+    away: isHome ? match.away.name : 'Man United',
+    homeScore: isHome ? scoreParts[0] : scoreParts[1] || '0',
+    awayScore: isHome ? scoreParts[1] || '0' : scoreParts[0],
+  };
+}
+
+function formatDate(utcTime: string): string {
+  const d = new Date(utcTime);
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+}
+
+function formatTime(utcTime: string): string {
+  const d = new Date(utcTime);
+  return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
 }
 
 export default function MatchesPage() {
-  const [match, setMatch] = useState<Match | null>(null);
-  const [table, setTable] = useState<TableEntry[] | null>(null);
-  const [manUtd, setManUtd] = useState<TableEntry | null>(null);
+  const [data, setData] = useState<MatchResponse | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
 
   async function fetchData() {
     try {
       const response = await fetch('/api/matches');
-      const data = await response.json();
-      
-      if (data.match) setMatch(data.match);
-      if (data.fullTable?.all) {
-        setTable(data.fullTable.all.slice(0, 10)); // Top 10
-        setManUtd(data.table);
-      }
+      const result = await response.json();
+      setData(result);
       setLastUpdate(new Date());
     } catch (err) {
-      setError('Failed to load match data');
+      console.error('Failed to fetch:', err);
     } finally {
       setLoading(false);
     }
@@ -67,28 +57,9 @@ export default function MatchesPage() {
 
   useEffect(() => {
     fetchData();
-    const interval = setInterval(fetchData, 30000); // Refresh every 30s
+    const interval = setInterval(fetchData, 60000);
     return () => clearInterval(interval);
   }, []);
-
-  function getStatusLabel(status: string): string {
-    if (status?.toLowerCase().includes('live')) return 'LIVE';
-    if (status?.toLowerCase().includes('finished')) return 'FT';
-    if (status?.toLowerCase().includes('halftime')) return 'HT';
-    return status || 'Upcoming';
-  }
-
-  function getEventIcon(type: string): string {
-    switch (type) {
-      case 'goal': return '⚽';
-      case 'card': return '🟨';
-      case 'sub': return '🔄';
-      case 'var': return '📺';
-      case 'penalty': return '⚽';
-      case 'missed_penalty': return '❌';
-      default: return '•';
-    }
-  }
 
   if (loading) {
     return (
@@ -102,84 +73,96 @@ export default function MatchesPage() {
     );
   }
 
+  const last = data?.last;
+  const next = data?.next;
+  const table = data?.table;
+  const fullTable = data?.fullTable?.all?.slice(0, 8) || [];
+  const lastDisplay = last ? getMatchDisplay(last) : null;
+  const nextDisplay = next ? getMatchDisplay(next) : null;
+
   return (
     <div className="space-y-8">
       {/* Header */}
       <div>
         <h1 className="text-3xl font-bold tracking-tight">Match Centre</h1>
         {lastUpdate && (
-          <p className="text-white/40 text-sm mt-1">
+          <p className="text-white/30 text-sm mt-1">
             Updated {lastUpdate.toLocaleTimeString()}
           </p>
         )}
       </div>
 
-      {/* Match Card */}
-      {match ? (
-        <div className="border border-white/10">
-          <div className="p-6">
-            <div className="flex items-center justify-between">
-              <div className="flex-1">
-                <p className="text-lg font-semibold">Man United</p>
-                <p className="text-4xl font-mono font-bold mt-1">{match.homeScore}</p>
+      {/* Last Result */}
+      {lastDisplay && last && (
+        <div>
+          <p className="text-xs uppercase tracking-wider text-white/40 mb-3">Last Result</p>
+          <div className="border border-white/10">
+            <div className="p-5">
+              <div className="flex items-center justify-between">
+                <div className="flex-1">
+                  <p className="font-medium">{lastDisplay.home}</p>
+                  <p className="text-3xl font-mono font-bold mt-1">{lastDisplay.homeScore}</p>
+                </div>
+                <div className="text-center px-4">
+                  <span className="text-xs text-white/40">{formatDate(last.status.utcTime)}</span>
+                </div>
+                <div className="flex-1 text-right">
+                  <p className="font-medium">{lastDisplay.away}</p>
+                  <p className="text-3xl font-mono font-bold mt-1">{lastDisplay.awayScore}</p>
+                </div>
               </div>
-              <div className="text-center px-6">
-                <span className="text-xs font-medium px-2 py-1 bg-[#DA291C]/20 text-[#DA291C]">
-                  {getStatusLabel(match.status)}
-                </span>
-                <p className="text-sm text-white/50 mt-2">
-                  {match.datetime ? new Date(match.datetime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : ''}
-                </p>
-              </div>
-              <div className="flex-1 text-right">
-                <p className="text-lg font-semibold">{match.awayTeam?.name || 'Opponent'}</p>
-                <p className="text-4xl font-mono font-bold mt-1">{match.awayScore}</p>
-              </div>
+            </div>
+            <div className="border-t border-white/10">
+              <Link
+                href={`/matches/${last.id}`}
+                className="block px-5 py-3 text-sm text-[#DA291C] hover:bg-white/5 transition-colors"
+              >
+                View details →
+              </Link>
             </div>
           </div>
-          
-          {/* Events */}
-          {match.events && match.events.length > 0 && (
-            <div className="border-t border-white/10 px-6 py-4">
-              <h3 className="text-xs uppercase tracking-wider text-white/40 mb-3">Events</h3>
-              <div className="space-y-2">
-                {match.events.slice(0, 10).map((event) => (
-                  <div key={event.id} className="flex items-center gap-3 text-sm">
-                    <span className="font-mono text-[#DA291C] w-8">{event.time}'</span>
-                    <span>{getEventIcon(event.type)}</span>
-                    <span className={event.team === 'home' ? 'font-medium' : 'text-white/60'}>
-                      {event.player || event.type}
-                    </span>
-                    {event.detail && <span className="text-white/40 text-xs">({event.detail})</span>}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
         </div>
-      ) : (
-        <div className="border border-white/10 p-8 text-center">
-          <p className="text-white/50">No match data available</p>
-          <p className="text-white/30 text-sm mt-1">
-            {error || 'No live or upcoming match found'}
-          </p>
+      )}
+
+      {/* Next Match */}
+      {nextDisplay && next && (
+        <div>
+          <p className="text-xs uppercase tracking-wider text-white/40 mb-3">Next Match</p>
+          <div className="border border-[#DA291C]/30 bg-[#DA291C]/5">
+            <div className="p-5">
+              <div className="flex items-center justify-between">
+                <div className="flex-1">
+                  <p className="font-medium">{nextDisplay.home}</p>
+                </div>
+                <div className="text-center px-4">
+                  <span className="text-xs text-white/40">vs</span>
+                </div>
+                <div className="flex-1 text-right">
+                  <p className="font-medium">{nextDisplay.away}</p>
+                </div>
+              </div>
+              <p className="text-center text-sm text-white/50 mt-2">
+                {formatDate(next.status.utcTime)} · {formatTime(next.status.utcTime)}
+              </p>
+            </div>
+          </div>
         </div>
       )}
 
       {/* League Table */}
-      {manUtd && (
+      {table && (
         <div>
-          <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg font-semibold">Premier League</h2>
-            <Link href="/table" className="text-sm text-[#DA291C] hover:underline">
-              Full Table →
-            </Link>
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-xs uppercase tracking-wider text-white/40">Premier League</p>
+            <span className="text-xs text-[#DA291C]">
+              #{table.idx} · {table.pts} pts
+            </span>
           </div>
           <div className="border border-white/10 overflow-hidden">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-white/10 text-left text-xs uppercase tracking-wider text-white/40">
-                  <th className="py-2 px-3">#</th>
+                  <th className="py-2 px-3 w-8">#</th>
                   <th className="py-2 px-3">Team</th>
                   <th className="py-2 px-3 text-center">P</th>
                   <th className="py-2 px-3 text-center">W</th>
@@ -190,11 +173,11 @@ export default function MatchesPage() {
                 </tr>
               </thead>
               <tbody>
-                {table?.map((entry) => (
+                {fullTable.map((entry) => (
                   <tr
                     key={entry.id}
                     className={`border-b border-white/5 ${
-                      entry.id === 10260 ? 'bg-[#DA291C]/10' : ''
+                      entry.id === '10260' ? 'bg-[#DA291C]/10' : ''
                     }`}
                   >
                     <td className="py-2 px-3 text-white/50">{entry.idx}</td>
@@ -203,10 +186,12 @@ export default function MatchesPage() {
                     <td className="py-2 px-3 text-center text-white/70">{entry.wins}</td>
                     <td className="py-2 px-3 text-center text-white/70">{entry.draws}</td>
                     <td className="py-2 px-3 text-center text-white/70">{entry.losses}</td>
-                    <td className={`py-2 px-3 text-center ${entry.goalConDiff > 0 ? 'text-green-400' : entry.goalConDiff < 0 ? 'text-red-400' : 'text-white/70'}`}>
+                    <td className={`py-2 px-3 text-center ${
+                      entry.goalConDiff > 0 ? 'text-green-400' : entry.goalConDiff < 0 ? 'text-red-400' : 'text-white/70'
+                    }`}>
                       {entry.goalConDiff > 0 ? '+' : ''}{entry.goalConDiff}
                     </td>
-                    <td className={`py-2 px-3 text-right font-medium ${entry.id === 10260 ? 'text-[#DA291C]' : ''}`}>
+                    <td className={`py-2 px-3 text-right font-medium ${entry.id === '10260' ? 'text-[#DA291C]' : ''}`}>
                       {entry.pts}
                     </td>
                   </tr>

--- a/src/app/matches/page.tsx
+++ b/src/app/matches/page.tsx
@@ -28,34 +28,28 @@ function getMatchDisplay(match: FixtureMatch) {
 }
 
 function formatDate(utcTime: string): string {
-  const d = new Date(utcTime);
-  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
+  return new Date(utcTime).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' });
 }
 
 function formatTime(utcTime: string): string {
-  const d = new Date(utcTime);
-  return d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+  return new Date(utcTime).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
 }
 
 export default function MatchesPage() {
   const [data, setData] = useState<MatchResponse | null>(null);
   const [loading, setLoading] = useState(true);
-  const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
-
-  async function fetchData() {
-    try {
-      const response = await fetch('/api/matches');
-      const result = await response.json();
-      setData(result);
-      setLastUpdate(new Date());
-    } catch (err) {
-      console.error('Failed to fetch:', err);
-    } finally {
-      setLoading(false);
-    }
-  }
 
   useEffect(() => {
+    async function fetchData() {
+      try {
+        const response = await fetch('/api/matches');
+        setData(await response.json());
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    }
     fetchData();
     const interval = setInterval(fetchData, 60000);
     return () => clearInterval(interval);
@@ -63,12 +57,10 @@ export default function MatchesPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="flex gap-1">
-          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
-        </div>
+      <div className="flex items-center gap-1.5 py-16">
+        <div className="w-1 h-1 bg-white/40 rounded-full animate-pulse" />
+        <div className="w-1 h-1 bg-white/40 rounded-full animate-pulse" style={{ animationDelay: '150ms' }} />
+        <div className="w-1 h-1 bg-white/40 rounded-full animate-pulse" style={{ animationDelay: '300ms' }} />
       </div>
     );
   }
@@ -81,113 +73,102 @@ export default function MatchesPage() {
   const nextDisplay = next ? getMatchDisplay(next) : null;
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-10">
       {/* Header */}
       <div>
-        <h1 className="text-3xl font-bold tracking-tight">Match Centre</h1>
-        {lastUpdate && (
-          <p className="text-white/30 text-sm mt-1">
-            Updated {lastUpdate.toLocaleTimeString()}
-          </p>
-        )}
+        <h1 className="text-2xl font-bold tracking-tight">Match Centre</h1>
       </div>
 
       {/* Last Result */}
       {lastDisplay && last && (
-        <div>
-          <p className="text-xs uppercase tracking-wider text-white/40 mb-3">Last Result</p>
+        <section>
+          <p className="text-[10px] uppercase tracking-[0.15em] text-white/35 mb-3">Last Result</p>
           <div className="border border-white/10">
-            <div className="p-5">
+            <div className="px-5 py-4">
               <div className="flex items-center justify-between">
                 <div className="flex-1">
-                  <p className="font-medium">{lastDisplay.home}</p>
-                  <p className="text-3xl font-mono font-bold mt-1">{lastDisplay.homeScore}</p>
+                  <p className="text-sm font-medium text-white/70">{lastDisplay.home}</p>
+                  <p className="text-[2rem] font-mono font-bold mt-0.5 leading-none">{lastDisplay.homeScore}</p>
                 </div>
                 <div className="text-center px-4">
-                  <span className="text-xs text-white/40">{formatDate(last.status.utcTime)}</span>
+                  <p className="text-[10px] text-white/30">{formatDate(last.status.utcTime)}</p>
                 </div>
                 <div className="flex-1 text-right">
-                  <p className="font-medium">{lastDisplay.away}</p>
-                  <p className="text-3xl font-mono font-bold mt-1">{lastDisplay.awayScore}</p>
+                  <p className="text-sm font-medium text-white/70">{lastDisplay.away}</p>
+                  <p className="text-[2rem] font-mono font-bold mt-0.5 leading-none">{lastDisplay.awayScore}</p>
                 </div>
               </div>
             </div>
-            <div className="border-t border-white/10">
-              <Link
-                href={`/matches/${last.id}`}
-                className="block px-5 py-3 text-sm text-[#DA291C] hover:bg-white/5 transition-colors"
-              >
-                View details →
-              </Link>
-            </div>
+            <Link
+              href={`/matches/${last.id}`}
+              className="block px-5 py-2.5 text-xs text-[#DA291C] border-t border-white/5 hover:bg-white/5 transition-colors"
+            >
+              View details →
+            </Link>
           </div>
-        </div>
+        </section>
       )}
 
       {/* Next Match */}
       {nextDisplay && next && (
-        <div>
-          <p className="text-xs uppercase tracking-wider text-white/40 mb-3">Next Match</p>
-          <div className="border border-[#DA291C]/30 bg-[#DA291C]/5">
-            <div className="p-5">
-              <div className="flex items-center justify-between">
-                <div className="flex-1">
-                  <p className="font-medium">{nextDisplay.home}</p>
-                </div>
-                <div className="text-center px-4">
-                  <span className="text-xs text-white/40">vs</span>
-                </div>
-                <div className="flex-1 text-right">
-                  <p className="font-medium">{nextDisplay.away}</p>
-                </div>
+        <section>
+          <p className="text-[10px] uppercase tracking-[0.15em] text-white/35 mb-3">Next Match</p>
+          <div className="border border-[#DA291C]/25 bg-[#DA291C]/[0.03] px-5 py-4">
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <p className="text-sm font-medium">{nextDisplay.home}</p>
               </div>
-              <p className="text-center text-sm text-white/50 mt-2">
-                {formatDate(next.status.utcTime)} · {formatTime(next.status.utcTime)}
-              </p>
+              <div className="text-center px-3">
+                <p className="text-[10px] text-white/30">vs</p>
+              </div>
+              <div className="flex-1 text-right">
+                <p className="text-sm font-medium">{nextDisplay.away}</p>
+              </div>
             </div>
+            <p className="text-xs text-white/40 mt-2 text-center">
+              {formatDate(next.status.utcTime)} · {formatTime(next.status.utcTime)}
+            </p>
           </div>
-        </div>
+        </section>
       )}
 
       {/* League Table */}
       {table && (
-        <div>
+        <section>
           <div className="flex items-center justify-between mb-3">
-            <p className="text-xs uppercase tracking-wider text-white/40">Premier League</p>
-            <span className="text-xs text-[#DA291C]">
-              #{table.idx} · {table.pts} pts
-            </span>
+            <p className="text-[10px] uppercase tracking-[0.15em] text-white/35">Premier League</p>
+            <span className="text-[10px] text-[#DA291C]">#{table.idx} · {table.pts} pts</span>
           </div>
-          <div className="border border-white/10 overflow-hidden">
-            <table className="w-full text-sm">
+          <div className="border border-white/10">
+            <table className="w-full text-[13px]">
               <thead>
-                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-wider text-white/40">
-                  <th className="py-2 px-3 w-8">#</th>
-                  <th className="py-2 px-3">Team</th>
-                  <th className="py-2 px-3 text-center">P</th>
-                  <th className="py-2 px-3 text-center">W</th>
-                  <th className="py-2 px-3 text-center">D</th>
-                  <th className="py-2 px-3 text-center">L</th>
-                  <th className="py-2 px-3 text-center">GD</th>
-                  <th className="py-2 px-3 text-right">Pts</th>
+                <tr className="border-b border-white/8 text-[10px] uppercase tracking-[0.1em] text-white/30">
+                  <th className="py-2.5 px-3 font-normal text-left w-6">#</th>
+                  <th className="py-2.5 px-3 font-normal text-left">Team</th>
+                  <th className="py-2.5 px-3 font-normal text-center w-8">P</th>
+                  <th className="py-2.5 px-3 font-normal text-center w-8">W</th>
+                  <th className="py-2.5 px-3 font-normal text-center w-8">D</th>
+                  <th className="py-2.5 px-3 font-normal text-center w-8">L</th>
+                  <th className="py-2.5 px-3 font-normal text-center w-8">GD</th>
+                  <th className="py-2.5 px-3 font-normal text-right w-8">Pts</th>
                 </tr>
               </thead>
               <tbody>
                 {fullTable.map((entry) => (
                   <tr
                     key={entry.id}
-                    className={`border-b border-white/5 ${
-                      entry.id === '10260' ? 'bg-[#DA291C]/10' : ''
+                    className={`border-b border-white/5 last:border-0 ${
+                      entry.id === '10260' ? 'bg-[#DA291C]/8' : ''
                     }`}
                   >
-                    <td className="py-2 px-3 text-white/50">{entry.idx}</td>
+                    <td className="py-2 px-3 text-white/35">{entry.idx}</td>
                     <td className="py-2 px-3 font-medium">{entry.shortName || entry.name}</td>
-                    <td className="py-2 px-3 text-center text-white/70">{entry.played}</td>
-                    <td className="py-2 px-3 text-center text-white/70">{entry.wins}</td>
-                    <td className="py-2 px-3 text-center text-white/70">{entry.draws}</td>
-                    <td className="py-2 px-3 text-center text-white/70">{entry.losses}</td>
+                    <td className="py-2 px-3 text-center text-white/50">{entry.played}</td>
+                    <td className="py-2 px-3 text-center text-white/50">{entry.wins}</td>
+                    <td className="py-2 px-3 text-center text-white/50">{entry.draws}</td>
+                    <td className="py-2 px-3 text-center text-white/50">{entry.losses}</td>
                     <td className={`py-2 px-3 text-center ${
-                      entry.goalConDiff > 0 ? 'text-green-400' : entry.goalConDiff < 0 ? 'text-red-400' : 'text-white/70'
+                      entry.goalConDiff > 0 ? 'text-green-400/80' : entry.goalConDiff < 0 ? 'text-red-400/80' : 'text-white/50'
                     }`}>
                       {entry.goalConDiff > 0 ? '+' : ''}{entry.goalConDiff}
                     </td>
@@ -199,7 +180,7 @@ export default function MatchesPage() {
               </tbody>
             </table>
           </div>
-        </div>
+        </section>
       )}
     </div>
   );

--- a/src/app/matches/page.tsx
+++ b/src/app/matches/page.tsx
@@ -1,86 +1,102 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 
 interface MatchEvent {
   id: string;
-  minute: number;
+  time: number;
   type: string;
-  team: string;
+  team: 'home' | 'away';
   player?: string;
   assist?: string;
   detail?: string;
 }
 
 interface Match {
-  id: string;
-  home_team: string;
-  away_team: string;
-  home_score: number;
-  away_score: number;
+  matchId: number;
   status: string;
+  homeTeam: { name: string; shortName: string };
+  awayTeam: { name: string; shortName: string };
+  homeScore: number;
+  awayScore: number;
   datetime: string;
   league: string;
-  events?: MatchEvent[];
+  events: MatchEvent[];
+}
+
+interface TableEntry {
+  name: string;
+  shortName: string;
+  id: number;
+  played: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  scoresStr: string;
+  goalConDiff: number;
+  pts: number;
+  idx: number;
 }
 
 export default function MatchesPage() {
   const [match, setMatch] = useState<Match | null>(null);
+  const [table, setTable] = useState<TableEntry[] | null>(null);
+  const [manUtd, setManUtd] = useState<TableEntry | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
+
+  async function fetchData() {
+    try {
+      const response = await fetch('/api/matches');
+      const data = await response.json();
+      
+      if (data.match) setMatch(data.match);
+      if (data.fullTable?.all) {
+        setTable(data.fullTable.all.slice(0, 10)); // Top 10
+        setManUtd(data.table);
+      }
+      setLastUpdate(new Date());
+    } catch (err) {
+      setError('Failed to load match data');
+    } finally {
+      setLoading(false);
+    }
+  }
 
   useEffect(() => {
-    async function fetchMatch() {
-      try {
-        const response = await fetch('/api/matches');
-        const data = await response.json();
-        if (data.match) {
-          setMatch(data.match);
-        }
-      } catch (err) {
-        setError('Failed to load match data');
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchMatch();
-    const interval = setInterval(fetchMatch, 30000); // Refresh every 30s
+    fetchData();
+    const interval = setInterval(fetchData, 30000); // Refresh every 30s
     return () => clearInterval(interval);
   }, []);
+
+  function getStatusLabel(status: string): string {
+    if (status?.toLowerCase().includes('live')) return 'LIVE';
+    if (status?.toLowerCase().includes('finished')) return 'FT';
+    if (status?.toLowerCase().includes('halftime')) return 'HT';
+    return status || 'Upcoming';
+  }
+
+  function getEventIcon(type: string): string {
+    switch (type) {
+      case 'goal': return '⚽';
+      case 'card': return '🟨';
+      case 'sub': return '🔄';
+      case 'var': return '📺';
+      case 'penalty': return '⚽';
+      case 'missed_penalty': return '❌';
+      default: return '•';
+    }
+  }
 
   if (loading) {
     return (
       <div className="flex items-center justify-center h-64">
         <div className="flex gap-1">
-          <div className="w-3 h-3 bg-white/50 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-          <div className="w-3 h-3 bg-white/50 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-          <div className="w-3 h-3 bg-white/50 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
-        </div>
-      </div>
-    );
-  }
-
-  if (error || !match) {
-    return (
-      <div className="space-y-8">
-        <h1 className="text-4xl font-bold">Match Centre</h1>
-        <div className="card text-center py-12">
-          <p className="text-white/50 mb-4">{error || 'No match data available'}</p>
-          <p className="text-sm text-white/30">
-            SportSRC API not configured or no live match. Connect to live data for real-time updates.
-          </p>
-        </div>
-        
-        {/* Placeholder for demo */}
-        <div className="card">
-          <p className="text-white/50 text-sm uppercase tracking-wider mb-4">Demo Mode</p>
-          <div className="text-center py-8">
-            <h2 className="text-3xl font-bold mb-2">Manchester United</h2>
-            <p className="text-xl text-white/70 mb-4">vs Next Opponent</p>
-            <p className="text-4xl font-mono text-[#FBE122]">0 - 0</p>
-            <p className="text-white/50 mt-4">Match not started yet</p>
-          </div>
+          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+          <div className="w-2 h-2 bg-white/40 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
         </div>
       </div>
     );
@@ -88,48 +104,115 @@ export default function MatchesPage() {
 
   return (
     <div className="space-y-8">
-      <h1 className="text-4xl font-bold">Match Centre</h1>
-
-      {/* Scoreboard */}
-      <div className="card">
-        <div className="flex items-center justify-between">
-          <div className="flex-1 text-center">
-            <p className="text-lg font-bold">Man United</p>
-            <p className="text-5xl font-mono font-bold mt-2">{match.home_score}</p>
-          </div>
-          <div className="text-center px-8">
-            <p className="text-white/50 text-sm uppercase tracking-wider">{match.status}</p>
-            <p className="text-xl font-mono mt-1">
-              {new Date(match.datetime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-            </p>
-          </div>
-          <div className="flex-1 text-center">
-            <p className="text-lg font-bold">{match.away_team}</p>
-            <p className="text-5xl font-mono font-bold mt-2">{match.away_score}</p>
-          </div>
-        </div>
-        <p className="text-center text-white/50 mt-4">{match.league}</p>
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Match Centre</h1>
+        {lastUpdate && (
+          <p className="text-white/40 text-sm mt-1">
+            Updated {lastUpdate.toLocaleTimeString()}
+          </p>
+        )}
       </div>
 
-      {/* Match Events */}
-      {match.events && match.events.length > 0 && (
-        <div className="card">
-          <h2 className="text-xl font-bold mb-4">Match Events</h2>
-          <div className="space-y-3">
-            {match.events.map((event) => (
-              <div
-                key={event.id}
-                className="flex items-center gap-4 py-2 border-b border-white/5 last:border-0"
-              >
-                <span className="font-mono text-[#FBE122] w-12">{event.minute}'</span>
-                <span className={`w-2 h-2 rounded-full ${event.team === 'home' ? 'bg-[#DA291C]' : 'bg-white/30'}`} />
-                <span className="flex-1">
-                  <span className="font-medium">{event.player}</span>
-                  {event.assist && <span className="text-white/50"> (assist: {event.assist})</span>}
-                </span>
-                <span className="text-white/50 capitalize">{event.type}</span>
+      {/* Match Card */}
+      {match ? (
+        <div className="border border-white/10">
+          <div className="p-6">
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <p className="text-lg font-semibold">Man United</p>
+                <p className="text-4xl font-mono font-bold mt-1">{match.homeScore}</p>
               </div>
-            ))}
+              <div className="text-center px-6">
+                <span className="text-xs font-medium px-2 py-1 bg-[#DA291C]/20 text-[#DA291C]">
+                  {getStatusLabel(match.status)}
+                </span>
+                <p className="text-sm text-white/50 mt-2">
+                  {match.datetime ? new Date(match.datetime).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : ''}
+                </p>
+              </div>
+              <div className="flex-1 text-right">
+                <p className="text-lg font-semibold">{match.awayTeam?.name || 'Opponent'}</p>
+                <p className="text-4xl font-mono font-bold mt-1">{match.awayScore}</p>
+              </div>
+            </div>
+          </div>
+          
+          {/* Events */}
+          {match.events && match.events.length > 0 && (
+            <div className="border-t border-white/10 px-6 py-4">
+              <h3 className="text-xs uppercase tracking-wider text-white/40 mb-3">Events</h3>
+              <div className="space-y-2">
+                {match.events.slice(0, 10).map((event) => (
+                  <div key={event.id} className="flex items-center gap-3 text-sm">
+                    <span className="font-mono text-[#DA291C] w-8">{event.time}'</span>
+                    <span>{getEventIcon(event.type)}</span>
+                    <span className={event.team === 'home' ? 'font-medium' : 'text-white/60'}>
+                      {event.player || event.type}
+                    </span>
+                    {event.detail && <span className="text-white/40 text-xs">({event.detail})</span>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className="border border-white/10 p-8 text-center">
+          <p className="text-white/50">No match data available</p>
+          <p className="text-white/30 text-sm mt-1">
+            {error || 'No live or upcoming match found'}
+          </p>
+        </div>
+      )}
+
+      {/* League Table */}
+      {manUtd && (
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold">Premier League</h2>
+            <Link href="/table" className="text-sm text-[#DA291C] hover:underline">
+              Full Table →
+            </Link>
+          </div>
+          <div className="border border-white/10 overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs uppercase tracking-wider text-white/40">
+                  <th className="py-2 px-3">#</th>
+                  <th className="py-2 px-3">Team</th>
+                  <th className="py-2 px-3 text-center">P</th>
+                  <th className="py-2 px-3 text-center">W</th>
+                  <th className="py-2 px-3 text-center">D</th>
+                  <th className="py-2 px-3 text-center">L</th>
+                  <th className="py-2 px-3 text-center">GD</th>
+                  <th className="py-2 px-3 text-right">Pts</th>
+                </tr>
+              </thead>
+              <tbody>
+                {table?.map((entry) => (
+                  <tr
+                    key={entry.id}
+                    className={`border-b border-white/5 ${
+                      entry.id === 10260 ? 'bg-[#DA291C]/10' : ''
+                    }`}
+                  >
+                    <td className="py-2 px-3 text-white/50">{entry.idx}</td>
+                    <td className="py-2 px-3 font-medium">{entry.shortName || entry.name}</td>
+                    <td className="py-2 px-3 text-center text-white/70">{entry.played}</td>
+                    <td className="py-2 px-3 text-center text-white/70">{entry.wins}</td>
+                    <td className="py-2 px-3 text-center text-white/70">{entry.draws}</td>
+                    <td className="py-2 px-3 text-center text-white/70">{entry.losses}</td>
+                    <td className={`py-2 px-3 text-center ${entry.goalConDiff > 0 ? 'text-green-400' : entry.goalConDiff < 0 ? 'text-red-400' : 'text-white/70'}`}>
+                      {entry.goalConDiff > 0 ? '+' : ''}{entry.goalConDiff}
+                    </td>
+                    <td className={`py-2 px-3 text-right font-medium ${entry.id === 10260 ? 'text-[#DA291C]' : ''}`}>
+                      {entry.pts}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         </div>
       )}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,56 +4,42 @@ import Link from 'next/link';
 
 export default function Home() {
   return (
-    <div className="space-y-12">
+    <div className="space-y-10">
       {/* Hero */}
-      <section className="text-left py-8">
-        <h1 className="text-5xl font-bold tracking-tight">
+      <div>
+        <h1 className="text-[2.75rem] font-bold tracking-tight leading-none">
           <span className="text-[#DA291C]">Glory Glory</span>
         </h1>
-        <p className="text-lg text-white/50 max-w-xl mt-3">
-          The smartest person in the pub, in your pocket. AI-powered match companion for Manchester United.
+        <p className="text-base text-white/40 mt-3 leading-relaxed">
+          The smartest person in the pub, in your pocket.
         </p>
-      </section>
+      </div>
 
       {/* Navigation */}
-      <nav className="grid grid-cols-1 gap-3">
-        <Link href="/matches" className="block p-5 border border-white/10 hover:border-[#DA291C]/50 transition-colors">
-          <div className="flex items-center justify-between">
+      <nav className="space-y-1">
+        {[
+          { href: '/matches', label: 'Match Centre', desc: 'Live scores, events, stats' },
+          { href: '/goals', label: 'Goals Archive', desc: 'Every goal, fully tagged' },
+          { href: '/chat', label: 'Ask Glory', desc: 'Natural language about United' },
+        ].map(({ href, label, desc }) => (
+          <Link
+            key={href}
+            href={href}
+            className="flex items-center justify-between py-3 border-b border-white/5 hover:border-white/20 transition-colors group"
+          >
             <div>
-              <h2 className="text-lg font-semibold">Match Centre</h2>
-              <p className="text-sm text-white/50 mt-1">Live scores, events, and stats</p>
+              <h2 className="text-base font-medium group-hover:text-[#DA291C] transition-colors">{label}</h2>
+              <p className="text-sm text-white/35 mt-0.5">{desc}</p>
             </div>
-            <span className="text-white/30">→</span>
-          </div>
-        </Link>
-
-        <Link href="/goals" className="block p-5 border border-white/10 hover:border-[#DA291C]/50 transition-colors">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-lg font-semibold">Goals Archive</h2>
-              <p className="text-sm text-white/50 mt-1">Every goal, fully tagged</p>
-            </div>
-            <span className="text-white/30">→</span>
-          </div>
-        </Link>
-
-        <Link href="/chat" className="block p-5 border border-white/10 hover:border-[#DA291C]/50 transition-colors">
-          <div className="flex items-center justify-between">
-            <div>
-              <h2 className="text-lg font-semibold">Ask Glory</h2>
-              <p className="text-sm text-white/50 mt-1">Natural language about United</p>
-            </div>
-            <span className="text-white/30">→</span>
-          </div>
-        </Link>
+            <span className="text-white/20 group-hover:text-white/50 transition-colors">→</span>
+          </Link>
+        ))}
       </nav>
 
       {/* Footer */}
-      <footer className="pt-8 border-t border-white/10">
-        <p className="text-sm text-white/30">
-          GGMU
-        </p>
-      </footer>
+      <div className="pt-8">
+        <p className="text-xs text-white/20 tracking-widest uppercase">GGMU</p>
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,116 +1,59 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { goals } from '@/lib/goals';
-
-function getTimeUntilMatch(): string {
-  // Placeholder - would connect to SportSRC API for real data
-  const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-  const now = new Date();
-  const dayName = days[now.getDay()];
-  return `${dayName} ${now.toLocaleDateString()}`;
-}
 
 export default function Home() {
-  const [time, setTime] = useState('');
-  const goalsThisSeason = goals.filter(g => g.scorer).length;
-  const wins = goals.filter(g => g.tags.includes('important_goal') || g.tags.includes('last_minute_winner')).length;
-
-  useEffect(() => {
-    setTime(getTimeUntilMatch());
-    const interval = setInterval(() => setTime(getTimeUntilMatch()), 60000);
-    return () => clearInterval(interval);
-  }, []);
-
   return (
     <div className="space-y-12">
       {/* Hero */}
-      <section className="text-center py-12">
-        <h1 className="text-5xl md:text-6xl font-bold mb-4">
-          <span className="text-[#DA291C]">Glory Glory</span> Man United
+      <section className="text-left py-8">
+        <h1 className="text-5xl font-bold tracking-tight">
+          <span className="text-[#DA291C]">Glory Glory</span>
         </h1>
-        <p className="text-xl text-white/70 max-w-2xl mx-auto">
-          The smartest person in the pub, in your pocket. AI-powered match companion for the modern fan.
+        <p className="text-lg text-white/50 max-w-xl mt-3">
+          The smartest person in the pub, in your pocket. AI-powered match companion for Manchester United.
         </p>
       </section>
 
-      {/* Next Match Card */}
-      <section className="card text-center py-12">
-        <p className="text-white/50 uppercase tracking-wider text-sm mb-2">Next Match</p>
-        <h2 className="text-3xl font-bold mb-2">Manchester United</h2>
-        <p className="text-xl text-white/70 mb-4">vs Opponent TBC</p>
-        <p className="text-2xl font-mono text-[#FBE122]">{time || 'Loading...'}</p>
-        <p className="text-white/50 mt-2">Connect to live data for real match info</p>
-      </section>
-
-      {/* Stats Grid */}
-      <section className="grid md:grid-cols-3 gap-6">
-        <div className="card text-center">
-          <p className="text-5xl font-bold text-[#DA291C]">{goalsThisSeason}</p>
-          <p className="text-white/50 mt-2">Goals This Season</p>
-        </div>
-        <div className="card text-center">
-          <p className="text-5xl font-bold text-[#DA291C]">{wins}</p>
-          <p className="text-white/50 mt-2">Match-Winning Goals</p>
-        </div>
-        <div className="card text-center">
-          <p className="text-5xl font-bold text-[#DA291C]">20</p>
-          <p className="text-white/50 mt-2">Games Played</p>
-        </div>
-      </section>
-
-      {/* Quick Actions */}
-      <section className="grid md:grid-cols-2 gap-6">
-        <Link href="/goals" className="card group hover:border-[#DA291C] transition-all">
-          <h3 className="text-2xl font-bold mb-2 group-hover:text-[#DA291C] transition-colors">
-            Browse Goals Archive
-          </h3>
-          <p className="text-white/50">
-            Every goal tagged and searchable. Find that strike you're looking for.
-          </p>
+      {/* Navigation */}
+      <nav className="grid grid-cols-1 gap-3">
+        <Link href="/matches" className="block p-5 border border-white/10 hover:border-[#DA291C]/50 transition-colors">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Match Centre</h2>
+              <p className="text-sm text-white/50 mt-1">Live scores, events, and stats</p>
+            </div>
+            <span className="text-white/30">→</span>
+          </div>
         </Link>
-        <Link href="/chat" className="card group hover:border-[#DA291C] transition-all">
-          <h3 className="text-2xl font-bold mb-2 group-hover:text-[#DA291C] transition-colors">
-            Ask Glory Glory
-          </h3>
-          <p className="text-white/50">
-            "Show me all Rashford volleys at Old Trafford" — just like that.
-          </p>
-        </Link>
-      </section>
 
-      {/* Recent Goals */}
-      <section>
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold">Recent Goals</h2>
-          <Link href="/goals" className="text-[#DA291C] hover:underline">
-            View all →
-          </Link>
-        </div>
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {goals.slice(0, 6).filter(g => g.scorer).map((goal) => (
-            <Link
-              key={goal.id}
-              href={`/goals/${goal.id}`}
-              className="card hover:border-[#DA291C] transition-all group"
-            >
-              <div className="flex items-start justify-between mb-2">
-                <div>
-                  <p className="font-bold text-lg">{goal.scorer}</p>
-                  <p className="text-white/50 text-sm">{goal.opponent} • {goal.minute}'</p>
-                </div>
-                <span className="text-[#FBE122] font-mono">{goal.score}</span>
-              </div>
-              <div className="flex flex-wrap gap-2 mt-3">
-                {goal.tags.slice(0, 2).map(tag => (
-                  <span key={tag} className="tag">{tag.replace(/_/g, ' ')}</span>
-                ))}
-              </div>
-            </Link>
-          ))}
-        </div>
-      </section>
+        <Link href="/goals" className="block p-5 border border-white/10 hover:border-[#DA291C]/50 transition-colors">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Goals Archive</h2>
+              <p className="text-sm text-white/50 mt-1">Every goal, fully tagged</p>
+            </div>
+            <span className="text-white/30">→</span>
+          </div>
+        </Link>
+
+        <Link href="/chat" className="block p-5 border border-white/10 hover:border-[#DA291C]/50 transition-colors">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold">Ask Glory</h2>
+              <p className="text-sm text-white/50 mt-1">Natural language about United</p>
+            </div>
+            <span className="text-white/30">→</span>
+          </div>
+        </Link>
+      </nav>
+
+      {/* Footer */}
+      <footer className="pt-8 border-t border-white/10">
+        <p className="text-sm text-white/30">
+          GGMU
+        </p>
+      </footer>
     </div>
   );
 }

--- a/src/components/EventTimeline.tsx
+++ b/src/components/EventTimeline.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { MatchEvent } from '@/lib/fotmob';
+
+interface EventTimelineProps {
+  events: MatchEvent[];
+  homeTeamId: string;
+}
+
+function getEventIcon(type: string): string {
+  switch (type) {
+    case 'goal': return '⚽';
+    case 'card_yellow': return '🟨';
+    case 'card_red': return '🟥';
+    case 'sub': return '🔄';
+    case 'var': return '📺';
+    case 'penalty': return '⚽';
+    case 'missed_penalty': return '❌';
+    case 'halftime': return '⸺';
+    case 'fulltime': return '✓';
+    default: return '•';
+  }
+}
+
+function getEventColor(type: string, team: string, homeTeamId: string): string {
+  const isHome = team === homeTeamId;
+  
+  switch (type) {
+    case 'goal': return isHome ? 'text-[#DA291C]' : 'text-white/60';
+    case 'card_yellow': return 'text-yellow-400';
+    case 'card_red': return 'text-red-500';
+    default: return 'text-white/60';
+  }
+}
+
+export default function EventTimeline({ events, homeTeamId }: EventTimelineProps) {
+  if (events.length === 0) {
+    return (
+      <div className="py-4 text-center text-white/30 text-sm">
+        No events available
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-0">
+      {events.map((event) => (
+        <div
+          key={event.id}
+          className="flex items-start gap-3 py-3 border-b border-white/5 last:border-0"
+        >
+          {/* Minute */}
+          <div className="w-10 text-right shrink-0">
+            <span className="font-mono text-sm font-medium text-white/50">
+              {event.minute || 0}'
+            </span>
+          </div>
+
+          {/* Icon */}
+          <div className="w-6 text-center shrink-0 text-base">
+            {getEventIcon(event.type)}
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            <p className={`text-sm leading-snug ${getEventColor(event.type, '', homeTeamId)}`}>
+              {event.player?.name || event.text || event.type}
+            </p>
+            {event.assist?.name && (
+              <p className="text-xs text-white/30 mt-0.5">
+                Assist: {event.assist.name}
+              </p>
+            )}
+            {event.homeScore !== undefined && event.awayScore !== undefined && (
+              <p className="text-xs text-white/30 mt-0.5">
+                {event.homeScore} – {event.awayScore}
+              </p>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/MatchStats.tsx
+++ b/src/components/MatchStats.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { MatchStats as MatchStatsType } from '@/lib/fotmob';
+
+interface MatchStatsProps {
+  stats: MatchStatsType;
+  homeTeamName: string;
+  awayTeamName: string;
+}
+
+function StatRow({ label, home, away }: { label: string; home: string | number; away: string | number }) {
+  const homeNum = typeof home === 'number' ? home : parseFloat(String(home)) || 0;
+  const awayNum = typeof away === 'number' ? away : parseFloat(String(away)) || 0;
+  const total = homeNum + awayNum;
+  const homePct = total > 0 ? (homeNum / total) * 100 : 50;
+
+  const isPossession = label.toLowerCase().includes('poss');
+
+  return (
+    <div className="grid grid-cols-[1fr_auto_1fr] gap-3 items-center py-2">
+      <div className="text-right">
+        <span className="text-sm font-medium">{home}</span>
+      </div>
+      <div className="text-center w-28">
+        <p className="text-xs uppercase tracking-wider text-white/40">{label}</p>
+        {/* Bar */}
+        {isPossession && (
+          <div className="flex h-1 mt-1 overflow-hidden rounded-sm">
+            <div className="bg-[#DA291C]" style={{ width: `${homePct}%` }} />
+            <div className="bg-white/20 flex-1" />
+          </div>
+        )}
+      </div>
+      <div className="text-left">
+        <span className="text-sm font-medium">{away}</span>
+      </div>
+    </div>
+  );
+}
+
+export default function MatchStats({ stats, homeTeamName, awayTeamName }: MatchStatsProps) {
+  return (
+    <div className="space-y-1">
+      {/* Team names */}
+      <div className="grid grid-cols-[1fr_auto_1fr] gap-3 mb-4">
+        <div className="text-right text-sm font-medium truncate">{homeTeamName}</div>
+        <div className="w-28" />
+        <div className="text-left text-sm font-medium truncate">{awayTeamName}</div>
+      </div>
+
+      <StatRow label="Possession" home={`${stats.possession.home}%`} away={`${stats.possession.away}%`} />
+      <StatRow label="Shots" home={stats.shots.home} away={stats.shots.away} />
+      <StatRow label="On Target" home={stats.shotsOnTarget.home} away={stats.shotsOnTarget.away} />
+      <StatRow label="Corners" home={stats.corners.home} away={stats.corners.away} />
+      <StatRow label="Fouls" home={stats.fouls.home} away={stats.fouls.away} />
+      <StatRow label="Yellow Cards" home={stats.yellowCards.home} away={stats.yellowCards.away} />
+      <StatRow label="Red Cards" home={stats.redCards.home} away={stats.redCards.away} />
+
+      {stats.xg && (
+        <StatRow label="xG" home={stats.xg.home.toFixed(2)} away={stats.xg.away.toFixed(2)} />
+      )}
+    </div>
+  );
+}

--- a/src/components/ShotMap.tsx
+++ b/src/components/ShotMap.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { Shot } from '@/lib/fotmob';
+
+interface ShotMapProps {
+  shots: Shot[];
+  homeTeamId: string;
+}
+
+export default function ShotMap({ shots, homeTeamId }: ShotMapProps) {
+  if (shots.length === 0) {
+    return (
+      <div className="border border-white/10 p-6 text-center">
+        <p className="text-white/40 text-sm">Shot map not available</p>
+      </div>
+    );
+  }
+
+  // SVG pitch dimensions (standard ratio: 105 x 68)
+  const PITCH_W = 520;
+  const PITCH_H = 360;
+  const HOME_IS_LEFT = true; // United playing left to right
+
+  // Normalize coordinates (FotMob uses 0-100 for both axes)
+  function normalizeX(x: number, isHome: boolean): number {
+    // FotMob: 0 = left side of pitch (home team goal)
+    // We want home team shooting at right goal
+    if (HOME_IS_LEFT) {
+      return isHome ? (x / 100) * PITCH_W : PITCH_W - (x / 100) * PITCH_W;
+    }
+    return (x / 100) * PITCH_W;
+  }
+
+  function normalizeY(y: number): number {
+    // FotMob: 0 = top, 100 = bottom
+    // SVG: 0 = top, H = bottom
+    return (y / 100) * PITCH_H;
+  }
+
+  // Goal line is at x=100 in FotMob coords for away team
+  // Penalty spot at x=83 for away team
+
+  function getDotColor(shot: Shot): string {
+    if (shot.goal) return '#DA291C';
+    if (shot.saved || shot.missed || shot.blocked || shot.offside) return '#FBE122';
+    if (shot.hitWoodwork) return '#FBE122';
+    return 'rgba(255,255,255,0.3)';
+  }
+
+  function getDotSize(xg: number): number {
+    // Size based on xG: 0.1 = small, 1.0 = large
+    return 6 + xg * 12;
+  }
+
+  const homeShots = shots.filter(s => String(s.teamId) === homeTeamId);
+  const awayShots = shots.filter(s => String(s.teamId) !== homeTeamId);
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm uppercase tracking-wider text-white/40">Shot Map</h3>
+        <div className="flex gap-4 text-xs text-white/50">
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-[#DA291C]"></span>
+            Goal
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-[#FBE122]"></span>
+            Missed
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-white/30"></span>
+            Other
+          </span>
+        </div>
+      </div>
+      
+      {/* Pitch SVG */}
+      <div className="relative border border-white/20" style={{ width: PITCH_W, maxWidth: '100%', aspectRatio: '105/68' }}>
+        <svg
+          viewBox={`0 0 ${PITCH_W} ${PITCH_H}`}
+          className="w-full h-full"
+          preserveAspectRatio="xMidYMid meet"
+        >
+          {/* Pitch background */}
+          <rect x="0" y="0" width={PITCH_W} height={PITCH_H} fill="#0B0523" />
+          
+          {/* Pitch markings */}
+          {/* Outer line */}
+          <rect x="2" y="2" width={PITCH_W - 4} height={PITCH_H - 4} fill="none" stroke="rgba(255,255,255,0.25)" strokeWidth="1" />
+          
+          {/* Center line */}
+          <line x1={PITCH_W / 2} y1="2" x2={PITCH_W / 2} y2={PITCH_H - 2} stroke="rgba(255,255,255,0.25)" strokeWidth="1" />
+          
+          {/* Center circle */}
+          <circle cx={PITCH_W / 2} cy={PITCH_H / 2} r={PITCH_H * 0.15} fill="none" stroke="rgba(255,255,255,0.25)" strokeWidth="1" />
+          <circle cx={PITCH_W / 2} cy={PITCH_H / 2} r="2" fill="rgba(255,255,255,0.25)" />
+          
+          {/* Left penalty area */}
+          <rect x="2" y={PITCH_H * 0.2} width={PITCH_W * 0.16} height={PITCH_H * 0.6} fill="none" stroke="rgba(255,255,255,0.25)" strokeWidth="1" />
+          
+          {/* Right penalty area */}
+          <rect x={PITCH_W - 2 - PITCH_W * 0.16} y={PITCH_H * 0.2} width={PITCH_W * 0.16} height={PITCH_H * 0.6} fill="none" stroke="rgba(255,255,255,0.25)" strokeWidth="1" />
+          
+          {/* Goals */}
+          <rect x="0" y={PITCH_H * 0.35} width="2" height={PITCH_H * 0.3} fill="none" stroke="rgba(255,255,255,0.5)" strokeWidth="1" />
+          <rect x={PITCH_W - 2} y={PITCH_H * 0.35} width="2" height={PITCH_H * 0.3} fill="none" stroke="rgba(255,255,255,0.5)" strokeWidth="1" />
+          
+          {/* Home shots (Man Utd) */}
+          {homeShots.map((shot) => {
+            const cx = normalizeX(shot.x, true);
+            const cy = normalizeY(shot.y);
+            const r = getDotSize(shot.expectedGoals);
+            return (
+              <g key={shot.id}>
+                <circle
+                  cx={cx}
+                  cy={cy}
+                  r={r}
+                  fill={getDotColor(shot)}
+                  opacity="0.9"
+                  stroke={shot.goal ? '#fff' : 'none'}
+                  strokeWidth={shot.goal ? 1 : 0}
+                />
+                {shot.goal && (
+                  <circle cx={cx} cy={cy} r={r * 1.5} fill="none" stroke="#DA291C" strokeWidth="1" opacity="0.4" />
+                )}
+              </g>
+            );
+          })}
+          
+          {/* Away shots */}
+          {awayShots.map((shot) => {
+            const cx = normalizeX(shot.x, false);
+            const cy = normalizeY(shot.y);
+            const r = getDotSize(shot.expectedGoals);
+            return (
+              <circle
+                key={shot.id}
+                cx={cx}
+                cy={cy}
+                r={r}
+                fill={getDotColor(shot)}
+                opacity="0.7"
+                stroke="none"
+              />
+            );
+          })}
+        </svg>
+      </div>
+      
+      {/* Legend */}
+      <div className="flex justify-between text-xs text-white/40 mt-2 px-1">
+        <span>Man Utd</span>
+        <span>Opposition</span>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/fotmob.ts
+++ b/src/lib/fotmob.ts
@@ -1,0 +1,307 @@
+/**
+ * Glory Glory — FotMob Data Layer
+ * 
+ * Uses FotMob's Next.js data endpoints. Pattern:
+ * 1. Fetch build ID from root page HTML
+ * 2. Use _next/data/{BUILD_ID}/... for JSON data
+ * 
+ * Endpoints that work:
+ * - /leagues/{id}/table/{slug}.json — league table
+ * - /match/{matchId}.json — match details
+ * 
+ * Team ID for Manchester United on FotMob: 10260
+ * League ID for Premier League: 47
+ */
+
+const FOTMOB_ROOT = 'https://www.fotmob.com';
+
+// Cache the build ID to avoid re-parsing HTML on every request
+let cachedBuildId: string | null = null;
+
+export interface Team {
+  id: number;
+  name: string;
+  shortName: string;
+  pageUrl: string;
+}
+
+export interface LeagueTableEntry {
+  name: string;
+  shortName: string;
+  id: number;
+  pageUrl: string;
+  played: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  scoresStr: string;
+  goalConDiff: number;
+  pts: number;
+  idx: number;
+  qualColor: string | null;
+}
+
+export interface LeagueTable {
+  all: LeagueTableEntry[];
+  home: LeagueTableEntry[];
+  away: LeagueTableEntry[];
+  form: LeagueTableEntry[];
+}
+
+export interface MatchEvent {
+  id: string;
+  time: number; // minute
+  type: 'goal' | 'card' | 'sub' | 'var' | 'kickoff' | 'halftime' | 'fulltime' | 'penalty' | 'missed_penalty';
+  team: 'home' | 'away';
+  player?: string;
+  assist?: string;
+  detail?: string;
+}
+
+export interface MatchDetails {
+  matchId: number;
+  status: string;
+  homeTeam: Team;
+  awayTeam: Team;
+  homeScore: number;
+  awayScore: number;
+  datetime: string;
+  league: string;
+  events: MatchEvent[];
+  stats?: MatchStats;
+  xg?: { home: number; away: number };
+  lineups?: LineupData;
+}
+
+export interface MatchStats {
+  possession: { home: number; away: number };
+  shots: { home: number; away: number };
+  shotsOnTarget: { home: number; away: number };
+  corners: { home: number; away: number };
+  fouls: { home: number; away: number };
+  yellowCards: { home: number; away: number };
+  redCards: { home: number; away: number };
+}
+
+export interface LineupData {
+  home: Player[];
+  away: Player[];
+  homeFormation?: string;
+  awayFormation?: string;
+}
+
+export interface Player {
+  id: number;
+  name: string;
+  shirtNumber?: number;
+  position?: string;
+  rating?: number;
+}
+
+async function getBuildId(): Promise<string> {
+  if (cachedBuildId) return cachedBuildId;
+
+  const html = await fetch(FOTMOB_ROOT).then(r => r.text());
+  const match = html.match(/"_next\/static\/([^/]+)\/chunks/);
+  if (!match) throw new Error('Could not find build ID in FotMob HTML');
+  
+  cachedBuildId = match[1];
+  return cachedBuildId;
+}
+
+async function fetchFotmob<T>(path: string): Promise<T> {
+  const buildId = await getBuildId();
+  const url = `${FOTMOB_ROOT}/_next/data/${buildId}${path}`;
+  const response = await fetch(url);
+  
+  if (!response.ok) {
+    throw new Error(`FotMob API error: ${response.status} for ${url}`);
+  }
+  
+  const data = await response.json();
+  return data.pageProps as T;
+}
+
+export async function getPremierLeagueTable(): Promise<LeagueTable> {
+  const data = await fetchFotmob<any>('/leagues/47/table/premier-league.json');
+  const table = data.table;
+  
+  return {
+    all: table.all.map(normalizeEntry),
+    home: table.home.map(normalizeEntry),
+    away: table.away.map(normalizeEntry),
+    form: (table.form || []).map(normalizeEntry),
+  };
+}
+
+function normalizeEntry(entry: any): LeagueTableEntry {
+  return {
+    name: entry.name,
+    shortName: entry.shortName,
+    id: entry.id,
+    pageUrl: entry.pageUrl,
+    played: entry.played,
+    wins: entry.wins,
+    draws: entry.draws,
+    losses: entry.losses,
+    scoresStr: entry.scoresStr,
+    goalConDiff: entry.goalConDiff,
+    pts: entry.pts,
+    idx: entry.idx,
+    qualColor: entry.qualColor,
+  };
+}
+
+export async function getMatchDetails(matchId: number): Promise<MatchDetails | null> {
+  try {
+    const data = await fetchFotmob<any>(`/match/${matchId}.json`);
+    return parseMatchDetails(data);
+  } catch (e) {
+    console.error('Failed to fetch match details:', e);
+    return null;
+  }
+}
+
+function parseMatchDetails(data: any): MatchDetails {
+  // The structure varies — look for match data in different places
+  const match = data.match || data.content || data;
+  
+  return {
+    matchId: match.matchId || match.id,
+    status: match.status || 'unknown',
+    homeTeam: match.homeTeam || match.home_team,
+    awayTeam: match.awayTeam || match.away_team,
+    homeScore: match.homeScore?.score ?? match.home_score ?? 0,
+    awayScore: match.awayScore?.score ?? match.away_score ?? 0,
+    datetime: match.datetime || match.startDateTime || match.date,
+    league: match.league || 'Premier League',
+    events: parseEvents(match.events || match.content?.events || []),
+    stats: parseStats(match.stats),
+    xg: match.xg || match.expectedGoals,
+    lineups: parseLineups(match.lineups),
+  };
+}
+
+function parseEvents(events: any[]): MatchEvent[] {
+  if (!events || !Array.isArray(events)) return [];
+  
+  return events.map(e => ({
+    id: e.id || String(Math.random()),
+    time: e.minute || e.time || 0,
+    type: mapEventType(e.type || e.eventType),
+    team: e.team === 'home' || e.isHome ? 'home' : 'away',
+    player: e.player?.name || e.playerName || e.player,
+    assist: e.assist?.name || e.assistedBy || e.assist,
+    detail: e.detail || e.description,
+  }));
+}
+
+function mapEventType(type: string): MatchEvent['type'] {
+  const t = (type || '').toLowerCase();
+  if (t.includes('goal')) return 'goal';
+  if (t.includes('card') && t.includes('red')) return 'card';
+  if (t.includes('card')) return 'card';
+  if (t.includes('sub')) return 'sub';
+  if (t.includes('var')) return 'var';
+  if (t.includes('penalty') && (t.includes('miss') || t.includes('saved') || t.includes('woodwork'))) return 'missed_penalty';
+  if (t.includes('penalty')) return 'penalty';
+  if (t.includes('kickoff')) return 'kickoff';
+  if (t.includes('half')) return 'halftime';
+  if (t.includes('fulltime') || t.includes('full')) return 'fulltime';
+  return 'goal';
+}
+
+function parseStats(stats: any): MatchStats | undefined {
+  if (!stats) return undefined;
+  return {
+    possession: stats.possession || { home: 50, away: 50 },
+    shots: stats.shots || { home: 0, away: 0 },
+    shotsOnTarget: stats.shotsOnTarget || { home: 0, away: 0 },
+    corners: stats.corners || { home: 0, away: 0 },
+    fouls: stats.fouls || { home: 0, away: 0 },
+    yellowCards: stats.yellowCards || { home: 0, away: 0 },
+    redCards: stats.redCards || { home: 0, away: 0 },
+  };
+}
+
+function parseLineups(lineups: any): LineupData | undefined {
+  if (!lineups) return undefined;
+  return {
+    home: (lineups.homeXI || []).map((p: any) => ({
+      id: p.id,
+      name: p.name,
+      shirtNumber: p.shirtNumber,
+      position: p.position,
+      rating: p.rating,
+    })),
+    away: (lineups.awayXI || []).map((p: any) => ({
+      id: p.id,
+      name: p.name,
+      shirtNumber: p.shirtNumber,
+      position: p.position,
+      rating: p.rating,
+    })),
+    homeFormation: lineups.homeFormation,
+    awayFormation: lineups.awayFormation,
+  };
+}
+
+export async function getManUtdMatches(date?: string): Promise<any[]> {
+  // Get today's matches or a specific date
+  const targetDate = date || new Date().toISOString().split('T')[0].replace(/-/g, '');
+  
+  try {
+    const data = await fetchFotmob<any>(`/leagues/47/matchlist.json?date=${targetDate}`);
+    const matches = data.matches || data.allMatches || [];
+    
+    // Filter for Man Utd
+    return matches.filter((m: any) => {
+      const home = m.homeTeam?.name || m.home_team?.name || '';
+      const away = m.awayTeam?.name || m.away_team?.name || '';
+      const homeShort = m.homeTeam?.shortName || m.home_shortName || '';
+      const awayShort = m.awayTeam?.shortName || m.away_shortName || '';
+      
+      return home.toLowerCase().includes('manchester united') ||
+             away.toLowerCase().includes('manchester united') ||
+             homeShort.toLowerCase().includes('man utd') ||
+             awayShort.toLowerCase().includes('man utd') ||
+             home.includes('United');
+    });
+  } catch (e) {
+    console.error('Failed to fetch matches:', e);
+    return [];
+  }
+}
+
+export async function getManUtdCurrentSeason(): Promise<{
+  table: LeagueTable | null;
+  recentMatches: any[];
+}> {
+  const [table, todayMatches] = await Promise.all([
+    getPremierLeagueTable().catch(() => null),
+    getManUtdMatches().catch(() => []),
+  ]);
+
+  return {
+    table,
+    recentMatches: todayMatches,
+  };
+}
+
+// Get current Man Utd match (live or upcoming)
+export async function getCurrentMatch(): Promise<MatchDetails | null> {
+  // First try to get today's matches
+  const matches = await getManUtdMatches();
+  
+  if (matches.length > 0) {
+    // Get detailed info for the first match
+    const matchId = matches[0].matchId || matches[0].id;
+    if (matchId) {
+      return getMatchDetails(matchId);
+    }
+  }
+  
+  // If no match today, try to get next scheduled match from table data
+  // This requires a more complex approach — for now return null
+  return null;
+}

--- a/src/lib/fotmob.ts
+++ b/src/lib/fotmob.ts
@@ -1,13 +1,13 @@
 /**
- * Glory Glory — FotMob Data Layer
+ * Glory Glory — FotMob Data Layer v2
  * 
- * Uses FotMob's Next.js data endpoints. Pattern:
- * 1. Fetch build ID from root page HTML
- * 2. Use _next/data/{BUILD_ID}/... for JSON data
+ * Uses FotMob's match page __NEXT_DATA__ for detailed match info.
+ * Pattern: fetch HTML page, extract __NEXT_DATA__, parse pageProps.
  * 
- * Endpoints that work:
- * - /leagues/{id}/table/{slug}.json — league table
- * - /match/{matchId}.json — match details
+ * Endpoints:
+ * - Match page: /match/{matchId} → header, content.liveticker, content.shotmap, content.stats, content.lineup
+ * - League: /leagues/47/matchlist.json → fixture list with basic match data
+ * - League table: /leagues/47/table/premier-league.json → standings
  * 
  * Team ID for Manchester United on FotMob: 10260
  * League ID for Premier League: 47
@@ -15,62 +15,66 @@
 
 const FOTMOB_ROOT = 'https://www.fotmob.com';
 
-// Cache the build ID to avoid re-parsing HTML on every request
-let cachedBuildId: string | null = null;
-
 export interface Team {
-  id: number;
+  id: string;
   name: string;
-  shortName: string;
-  pageUrl: string;
+  score: number;
+  imageUrl: string;
 }
 
-export interface LeagueTableEntry {
-  name: string;
-  shortName: string;
-  id: number;
-  pageUrl: string;
-  played: number;
-  wins: number;
-  draws: number;
-  losses: number;
-  scoresStr: string;
-  goalConDiff: number;
-  pts: number;
-  idx: number;
-  qualColor: string | null;
+export interface MatchStatus {
+  utcTime: string;
+  scoreStr: string;
+  finished: boolean;
+  started: boolean;
+  reason: {
+    short: string;
+    long: string;
+  };
+  halves?: any;
+  liveTime?: { text: string };
 }
 
-export interface LeagueTable {
-  all: LeagueTableEntry[];
-  home: LeagueTableEntry[];
-  away: LeagueTableEntry[];
-  form: LeagueTableEntry[];
+export interface MatchHeader {
+  matchId: number;
+  teams: Team[];
+  status: MatchStatus;
 }
 
 export interface MatchEvent {
   id: string;
-  time: number; // minute
-  type: 'goal' | 'card' | 'sub' | 'var' | 'kickoff' | 'halftime' | 'fulltime' | 'penalty' | 'missed_penalty';
-  team: 'home' | 'away';
-  player?: string;
-  assist?: string;
-  detail?: string;
+  minute: number;
+  type: string;
+  text?: string;
+  player?: { name: string; id: number };
+  assist?: { name: string; id: number };
+  homeScore?: number;
+  awayScore?: number;
 }
 
-export interface MatchDetails {
-  matchId: number;
-  status: string;
-  homeTeam: Team;
-  awayTeam: Team;
-  homeScore: number;
-  awayScore: number;
-  datetime: string;
-  league: string;
-  events: MatchEvent[];
-  stats?: MatchStats;
-  xg?: { home: number; away: number };
-  lineups?: LineupData;
+export interface Shot {
+  id: string;
+  playerId: number;
+  playerName: string;
+  teamId: number;
+  min: number;
+  expectedGoals: number;
+  eventType: string;
+  x: number;
+  y: number;
+  isHome: boolean;
+  goal: boolean;
+  saved: boolean;
+  missed: boolean;
+  blocked: boolean;
+  offside: boolean;
+  hitWoodwork: boolean;
+}
+
+export interface StatItem {
+  title: string;
+  homeValue: string;
+  awayValue: string;
 }
 
 export interface MatchStats {
@@ -81,65 +85,116 @@ export interface MatchStats {
   fouls: { home: number; away: number };
   yellowCards: { home: number; away: number };
   redCards: { home: number; away: number };
+  xg?: { home: number; away: number };
 }
 
-export interface LineupData {
-  home: Player[];
-  away: Player[];
-  homeFormation?: string;
-  awayFormation?: string;
-}
-
-export interface Player {
+export interface LineupPlayer {
   id: number;
   name: string;
+  position: string;
   shirtNumber?: number;
-  position?: string;
   rating?: number;
 }
 
+export interface Lineup {
+  formation: string;
+  xi: LineupPlayer[];
+  bench: LineupPlayer[];
+}
+
+export interface MatchDetails {
+  matchId: number;
+  header: MatchHeader;
+  events: MatchEvent[];
+  shots: Shot[];
+  stats: MatchStats;
+  homeLineup?: Lineup;
+  awayLineup?: Lineup;
+  homeTeam: { id: string; name: string };
+  awayTeam: { id: string; name: string };
+  homeScore: number;
+  awayScore: number;
+  status: MatchStatus;
+}
+
+export interface LeagueTableEntry {
+  name: string;
+  shortName: string;
+  id: string;
+  played: number;
+  wins: number;
+  draws: number;
+  losses: number;
+  scoresStr: string;
+  goalConDiff: number;
+  pts: number;
+  idx: number;
+  qualColor?: string;
+  imageUrl?: string;
+}
+
+export interface LeagueTable {
+  all: LeagueTableEntry[];
+  home: LeagueTableEntry[];
+  away: LeagueTableEntry[];
+}
+
+export interface FixtureMatch {
+  id: string;
+  home: { id: string; name: string; shortName: string };
+  away: { id: string; name: string; shortName: string };
+  status: {
+    utcTime: string;
+    scoreStr?: string;
+    finished?: boolean;
+    liveTime?: { text: string };
+    started?: boolean;
+  };
+}
+
+export interface ManUtdMatch extends MatchDetails {
+  // Additional fields from fixture
+  pageUrl?: string;
+  round?: string;
+}
+
+let cachedBuildId: string | null = null;
+
 async function getBuildId(): Promise<string> {
   if (cachedBuildId) return cachedBuildId;
-
   const html = await fetch(FOTMOB_ROOT).then(r => r.text());
   const match = html.match(/"_next\/static\/([^/]+)\/chunks/);
   if (!match) throw new Error('Could not find build ID in FotMob HTML');
-  
   cachedBuildId = match[1];
   return cachedBuildId;
 }
 
-async function fetchFotmob<T>(path: string): Promise<T> {
+// === League Table ===
+async function fetchLeagueData<T>(path: string): Promise<T> {
   const buildId = await getBuildId();
   const url = `${FOTMOB_ROOT}/_next/data/${buildId}${path}`;
   const response = await fetch(url);
-  
-  if (!response.ok) {
-    throw new Error(`FotMob API error: ${response.status} for ${url}`);
-  }
-  
+  if (!response.ok) throw new Error(`FotMob API error: ${response.status}`);
   const data = await response.json();
   return data.pageProps as T;
 }
 
 export async function getPremierLeagueTable(): Promise<LeagueTable> {
-  const data = await fetchFotmob<any>('/leagues/47/table/premier-league.json');
+  const data = await fetchLeagueData<any>('/leagues/47/table/premier-league.json');
   const table = data.table;
   
   return {
-    all: table.all.map(normalizeEntry),
-    home: table.home.map(normalizeEntry),
-    away: table.away.map(normalizeEntry),
-    form: (table.form || []).map(normalizeEntry),
+    all: table.all.map(normalizeTableEntry),
+    home: table.home.map(normalizeTableEntry),
+    away: table.away.map(normalizeTableEntry),
   };
 }
 
-function normalizeEntry(entry: any): LeagueTableEntry {
+function normalizeTableEntry(entry: any): LeagueTableEntry {
   return {
     name: entry.name,
-    shortName: entry.shortName,
-    id: entry.id,
-    pageUrl: entry.pageUrl,
+    shortName: entry.shortName || entry.name,
+    id: String(entry.id),
     played: entry.played,
     wins: entry.wins,
     draws: entry.draws,
@@ -149,159 +204,244 @@ function normalizeEntry(entry: any): LeagueTableEntry {
     pts: entry.pts,
     idx: entry.idx,
     qualColor: entry.qualColor,
+    imageUrl: entry.imageUrl,
   };
 }
 
+// === Fixture List ===
+export async function getManUtdFixtures(): Promise<FixtureMatch[]> {
+  const data = await fetchLeagueData<any>('/leagues/47/matchlist.json');
+  const allMatches: any[] = data.fixtures?.allMatches || [];
+  
+  return allMatches
+    .filter(m => m.home?.id === '10260' || m.away?.id === '10260')
+    .map(m => ({
+      id: m.id,
+      home: m.home,
+      away: m.away,
+      status: {
+        utcTime: m.status?.utcTime,
+        scoreStr: m.status?.scoreStr,
+        finished: m.status?.finished,
+        liveTime: m.status?.liveTime,
+        started: m.status?.started,
+      },
+      pageUrl: m.pageUrl,
+      round: m.round,
+    }));
+}
+
+// === Match Details (from match page HTML) ===
 export async function getMatchDetails(matchId: number): Promise<MatchDetails | null> {
   try {
-    const data = await fetchFotmob<any>(`/match/${matchId}.json`);
-    return parseMatchDetails(data);
+    const url = `${FOTMOB_ROOT}/match/${matchId}`;
+    const response = await fetch(url);
+    const html = await response.text();
+    
+    const nextDataMatch = html.match(/id="__NEXT_DATA__"[^>]*>([^<]+)</);
+    if (!nextDataMatch) return null;
+    
+    const data = JSON.parse(nextDataMatch[1]);
+    const pp = data.props.pageProps;
+    const header = pp.header;
+    const content = pp.content || {};
+    
+    // Parse teams
+    const teams: Team[] = (header.teams || []).map((t: any) => ({
+      id: String(t.id),
+      name: t.Name,
+      score: t.score,
+      imageUrl: t.imageUrl,
+    }));
+    
+    const homeTeam = teams[0];
+    const awayTeam = teams[1];
+    
+    // Parse events from liveticker
+    const events: MatchEvent[] = [];
+    const liveticker = content.liveticker?.teams || {};
+    for (const [teamId, teamEvents] of Object.entries(liveticker)) {
+      if (Array.isArray(teamEvents)) {
+        for (const e of teamEvents) {
+          events.push({
+            id: String(e.id),
+            minute: e.minute || e.time,
+            type: mapEventType(e.type || e.eventType),
+            text: e.text,
+            player: e.player,
+            assist: e.assist,
+            homeScore: e.homeScore,
+            awayScore: e.awayScore,
+          });
+        }
+      }
+    }
+    
+    // Sort by minute
+    events.sort((a, b) => a.minute - b.minute);
+    
+    // Parse shots
+    const shots: Shot[] = [];
+    const rawShots: any[] = content.shotmap?.shots || [];
+    for (const s of rawShots) {
+      const isHome = String(s.teamId) === String(homeTeam?.id);
+      shots.push({
+        id: String(s.id),
+        playerId: s.playerId,
+        playerName: s.playerName,
+        teamId: s.teamId,
+        min: s.min,
+        expectedGoals: s.expectedGoals || 0,
+        eventType: s.eventType,
+        x: s.x,
+        y: s.y,
+        isHome,
+        goal: s.eventType === 'Goal',
+        saved: s.eventType === 'AttemptSaved',
+        missed: s.eventType === 'AttemptMissed',
+        blocked: s.eventType === 'AttemptBlocked',
+        offside: s.eventType === 'OffsideWkeeper',
+        hitWoodwork: s.eventType === 'HitWoodwork',
+      });
+    }
+    
+    // Parse stats
+    const statsPeriod = content.stats?.Periods?.[0]?.stats || [];
+    const stats = parseStats(statsPeriod, shots);
+    
+    // Parse lineups
+    const homeLineup = parseLineup(content.lineup?.homeTeam);
+    const awayLineup = parseLineup(content.lineup?.awayTeam);
+    
+    return {
+      matchId,
+      header: {
+        matchId,
+        teams,
+        status: header.status,
+      },
+      events,
+      shots,
+      stats,
+      homeLineup,
+      awayLineup,
+      homeTeam: { id: homeTeam?.id || '', name: homeTeam?.name || '' },
+      awayTeam: { id: awayTeam?.id || '', name: awayTeam?.name || '' },
+      homeScore: homeTeam?.score || 0,
+      awayScore: awayTeam?.score || 0,
+      status: header.status,
+    };
   } catch (e) {
     console.error('Failed to fetch match details:', e);
     return null;
   }
 }
 
-function parseMatchDetails(data: any): MatchDetails {
-  // The structure varies — look for match data in different places
-  const match = data.match || data.content || data;
-  
-  return {
-    matchId: match.matchId || match.id,
-    status: match.status || 'unknown',
-    homeTeam: match.homeTeam || match.home_team,
-    awayTeam: match.awayTeam || match.away_team,
-    homeScore: match.homeScore?.score ?? match.home_score ?? 0,
-    awayScore: match.awayScore?.score ?? match.away_score ?? 0,
-    datetime: match.datetime || match.startDateTime || match.date,
-    league: match.league || 'Premier League',
-    events: parseEvents(match.events || match.content?.events || []),
-    stats: parseStats(match.stats),
-    xg: match.xg || match.expectedGoals,
-    lineups: parseLineups(match.lineups),
-  };
-}
-
-function parseEvents(events: any[]): MatchEvent[] {
-  if (!events || !Array.isArray(events)) return [];
-  
-  return events.map(e => ({
-    id: e.id || String(Math.random()),
-    time: e.minute || e.time || 0,
-    type: mapEventType(e.type || e.eventType),
-    team: e.team === 'home' || e.isHome ? 'home' : 'away',
-    player: e.player?.name || e.playerName || e.player,
-    assist: e.assist?.name || e.assistedBy || e.assist,
-    detail: e.detail || e.description,
-  }));
-}
-
-function mapEventType(type: string): MatchEvent['type'] {
+function mapEventType(type: string): string {
   const t = (type || '').toLowerCase();
-  if (t.includes('goal')) return 'goal';
-  if (t.includes('card') && t.includes('red')) return 'card';
-  if (t.includes('card')) return 'card';
-  if (t.includes('sub')) return 'sub';
+  if (t.includes('goal') || t === 'goal') return 'goal';
+  if (t.includes('yellow')) return 'card_yellow';
+  if (t.includes('red')) return 'card_red';
+  if (t.includes('sub') || t.includes('subst')) return 'sub';
   if (t.includes('var')) return 'var';
   if (t.includes('penalty') && (t.includes('miss') || t.includes('saved') || t.includes('woodwork'))) return 'missed_penalty';
   if (t.includes('penalty')) return 'penalty';
   if (t.includes('kickoff')) return 'kickoff';
-  if (t.includes('half')) return 'halftime';
-  if (t.includes('fulltime') || t.includes('full')) return 'fulltime';
-  return 'goal';
+  if (t.includes('half') && t.includes('end')) return 'halftime';
+  if (t.includes('full') || t.includes('finished')) return 'fulltime';
+  return 'other';
 }
 
-function parseStats(stats: any): MatchStats | undefined {
-  if (!stats) return undefined;
-  return {
-    possession: stats.possession || { home: 50, away: 50 },
-    shots: stats.shots || { home: 0, away: 0 },
-    shotsOnTarget: stats.shotsOnTarget || { home: 0, away: 0 },
-    corners: stats.corners || { home: 0, away: 0 },
-    fouls: stats.fouls || { home: 0, away: 0 },
-    yellowCards: stats.yellowCards || { home: 0, away: 0 },
-    redCards: stats.redCards || { home: 0, away: 0 },
+function parseStats(rawStats: any[], shots: Shot[]): MatchStats {
+  const stats: MatchStats = {
+    possession: { home: 50, away: 50 },
+    shots: { home: 0, away: 0 },
+    shotsOnTarget: { home: 0, away: 0 },
+    corners: { home: 0, away: 0 },
+    fouls: { home: 0, away: 0 },
+    yellowCards: { home: 0, away: 0 },
+    redCards: { home: 0, away: 0 },
   };
-}
-
-function parseLineups(lineups: any): LineupData | undefined {
-  if (!lineups) return undefined;
-  return {
-    home: (lineups.homeXI || []).map((p: any) => ({
-      id: p.id,
-      name: p.name,
-      shirtNumber: p.shirtNumber,
-      position: p.position,
-      rating: p.rating,
-    })),
-    away: (lineups.awayXI || []).map((p: any) => ({
-      id: p.id,
-      name: p.name,
-      shirtNumber: p.shirtNumber,
-      position: p.position,
-      rating: p.rating,
-    })),
-    homeFormation: lineups.homeFormation,
-    awayFormation: lineups.awayFormation,
-  };
-}
-
-export async function getManUtdMatches(date?: string): Promise<any[]> {
-  // Get today's matches or a specific date
-  const targetDate = date || new Date().toISOString().split('T')[0].replace(/-/g, '');
   
-  try {
-    const data = await fetchFotmob<any>(`/leagues/47/matchlist.json?date=${targetDate}`);
-    const matches = data.matches || data.allMatches || [];
+  for (const s of rawStats) {
+    const title = (s.title || '').toLowerCase();
+    const homeVal = parseFloat(s.homeValue) || 0;
+    const awayVal = parseFloat(s.awayValue) || 0;
     
-    // Filter for Man Utd
-    return matches.filter((m: any) => {
-      const home = m.homeTeam?.name || m.home_team?.name || '';
-      const away = m.awayTeam?.name || m.away_team?.name || '';
-      const homeShort = m.homeTeam?.shortName || m.home_shortName || '';
-      const awayShort = m.awayTeam?.shortName || m.away_shortName || '';
-      
-      return home.toLowerCase().includes('manchester united') ||
-             away.toLowerCase().includes('manchester united') ||
-             homeShort.toLowerCase().includes('man utd') ||
-             awayShort.toLowerCase().includes('man utd') ||
-             home.includes('United');
-    });
-  } catch (e) {
-    console.error('Failed to fetch matches:', e);
-    return [];
-  }
-}
-
-export async function getManUtdCurrentSeason(): Promise<{
-  table: LeagueTable | null;
-  recentMatches: any[];
-}> {
-  const [table, todayMatches] = await Promise.all([
-    getPremierLeagueTable().catch(() => null),
-    getManUtdMatches().catch(() => []),
-  ]);
-
-  return {
-    table,
-    recentMatches: todayMatches,
-  };
-}
-
-// Get current Man Utd match (live or upcoming)
-export async function getCurrentMatch(): Promise<MatchDetails | null> {
-  // First try to get today's matches
-  const matches = await getManUtdMatches();
-  
-  if (matches.length > 0) {
-    // Get detailed info for the first match
-    const matchId = matches[0].matchId || matches[0].id;
-    if (matchId) {
-      return getMatchDetails(matchId);
+    if (title.includes('possession')) {
+      stats.possession = { home: homeVal, away: awayVal };
+    } else if (title.includes('shots') && !title.includes('target')) {
+      stats.shots = { home: homeVal, away: awayVal };
+    } else if (title.includes('target')) {
+      stats.shotsOnTarget = { home: homeVal, away: awayVal };
+    } else if (title.includes('corner')) {
+      stats.corners = { home: homeVal, away: awayVal };
+    } else if (title.includes('foul')) {
+      stats.fouls = { home: homeVal, away: awayVal };
+    } else if (title.includes('yellow')) {
+      stats.yellowCards = { home: homeVal, away: awayVal };
+    } else if (title.includes('red')) {
+      stats.redCards = { home: homeVal, away: awayVal };
     }
   }
   
-  // If no match today, try to get next scheduled match from table data
-  // This requires a more complex approach — for now return null
-  return null;
+  // Calculate from shots if not in stats
+  if (stats.shots.home === 0 && stats.shots.away === 0) {
+    stats.shots.home = shots.filter(s => s.isHome).length;
+    stats.shots.away = shots.filter(s => !s.isHome).length;
+  }
+  
+  // Calculate xG from shots
+  const homeXg = shots.filter(s => s.isHome).reduce((sum, s) => sum + (s.goal ? s.expectedGoals : 0), 0);
+  const awayXg = shots.filter(s => !s.isHome).reduce((sum, s) => sum + (s.goal ? s.expectedGoals : 0), 0);
+  if (homeXg > 0 || awayXg > 0) {
+    stats.xg = { home: parseFloat(homeXg.toFixed(2)), away: parseFloat(awayXg.toFixed(2)) };
+  }
+  
+  return stats;
+}
+
+function parseLineup(data: any): Lineup | undefined {
+  if (!data) return undefined;
+  return {
+    formation: data.formation,
+    xi: (data.xi || []).map((p: any) => ({
+      id: p.id,
+      name: p.name,
+      position: p.position,
+      shirtNumber: p.shirtNumber,
+      rating: p.rating,
+    })),
+    bench: (data.bench || []).map((p: any) => ({
+      id: p.id,
+      name: p.name,
+      position: p.position,
+      shirtNumber: p.shirtNumber,
+      rating: p.rating,
+    })),
+  };
+}
+
+// === Convenience functions ===
+export async function getCurrentAndUpcomingMatch(): Promise<{
+  current: FixtureMatch | null;
+  next: FixtureMatch | null;
+  last: FixtureMatch | null;
+}> {
+  const fixtures = await getManUtdFixtures();
+  const now = Date.now();
+  
+  const upcoming = fixtures
+    .filter(m => !m.status.finished && m.status.started !== false && new Date(m.status.utcTime).getTime() > now)
+    .sort((a, b) => new Date(a.status.utcTime).getTime() - new Date(b.status.utcTime).getTime());
+  
+  const finished = fixtures
+    .filter(m => m.status.finished)
+    .sort((a, b) => new Date(b.status.utcTime).getTime() - new Date(a.status.utcTime).getTime());
+  
+  return {
+    current: upcoming[0] || null,
+    next: upcoming[0] || null,
+    last: finished[0] || null,
+  };
 }

--- a/src/lib/sportsrc.ts
+++ b/src/lib/sportsrc.ts
@@ -1,78 +1,185 @@
-import axios from 'axios';
+/**
+ * Glory Glory — SportSRC Data Layer
+ * 
+ * API V2 — Basic plan
+ * Docs: https://sportsrc.org/v2/#docs
+ * Header: X-API-KEY
+ */
 
 const SPORTSRC_BASE = 'https://api.sportsrc.org/v2';
+const API_KEY = process.env.SPORTSRC_API_KEY || '';
 
-export interface MatchEvent {
+function headers() {
+  return {
+    'X-API-KEY': API_KEY,
+    'Accept': 'application/json',
+  };
+}
+
+export interface StreamSource {
+  source: string;
+  embedUrl: string;
+  hd: boolean;
+  language: string;
+  title?: string;
+}
+
+export interface MatchInfo {
   id: string;
+  title: string;
   time: string;
-  type: 'goal' | 'card' | 'sub' | 'var' | 'kickoff' | 'halftime' | 'fulltime';
-  team: 'home' | 'away';
-  player?: string;
-  assist?: string;
-  minute?: number;
-  detail?: string;
-}
-
-export interface Match {
-  id: string;
+  status: string;
   league: string;
-  home_team: string;
-  away_team: string;
-  home_score: number;
-  away_score: number;
-  status: 'live' | 'finished' | 'upcoming' | 'postponed';
-  datetime: string;
-  has_stream?: boolean;
-  has_standing?: boolean;
-  events?: MatchEvent[];
+  homeTeam: string;
+  awayTeam: string;
+  homeScore: number;
+  awayScore: number;
 }
 
-export interface MatchStats {
-  possession: { home: number; away: number };
-  shots: { home: number; away: number };
-  shotsOnTarget: { home: number; away: number };
-  corners: { home: number; away: number };
-  fouls: { home: number; away: number };
+export interface MatchDetail {
+  matchInfo: MatchInfo;
+  sources: StreamSource[];
+  info: string;
 }
 
-export async function getLiveScores(): Promise<Match[]> {
-  try {
-    const response = await axios.get(`${SPORTSRC_BASE}/scores`, {
-      timeout: 10000,
-    });
-    // Filter for Man Utd (team ID 33 or name variants)
-    const matches: Match[] = response.data?.data || response.data || [];
-    return matches.filter((m: Match) =>
-      m.home_team?.toLowerCase().includes('manchester united') ||
-      m.away_team?.toLowerCase().includes('manchester united') ||
-      m.home_team?.toLowerCase().includes('man utd') ||
-      m.away_team?.toLowerCase().includes('man utd')
-    );
-  } catch (error) {
-    console.error('SportSRC API error:', error);
-    return [];
+async function apiGet(params: Record<string, string>): Promise<any> {
+  const url = new URL(SPORTSRC_BASE);
+  url.searchParams.set('key', API_KEY);
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
   }
+  
+  const res = await fetch(url.toString(), { headers: headers() });
+  if (!res.ok) throw new Error(`SportSRC error: ${res.status}`);
+  const data = await res.json();
+  if (!data.success) throw new Error(data.message || 'SportSRC API error');
+  return data;
 }
 
-export async function getMatchDetails(matchId: string): Promise<Match | null> {
+// === Get match detail with stream sources ===
+export async function getMatchDetail(sportsrcId: string): Promise<MatchDetail | null> {
   try {
-    const response = await axios.get(`${SPORTSRC_BASE}/match/${matchId}`, {
-      timeout: 10000,
-    });
-    return response.data;
-  } catch (error) {
-    console.error('SportSRC match details error:', error);
+    const data = await apiGet({ type: 'detail', id: sportsrcId });
+    const raw = data.data;
+    
+    const info = raw.match_info;
+    const sources: StreamSource[] = (raw.sources || [])
+      .filter((s: any) => s.embedUrl)
+      .map((s: any) => ({
+        source: s.source || s.name || 'Stream',
+        embedUrl: s.embed_url || s.embedUrl || s.url,
+        hd: s.hd || false,
+        language: s.language || '',
+        title: s.title || s.name,
+      }));
+
+    return {
+      matchInfo: {
+        id: info.id,
+        title: info.title,
+        time: info.time,
+        status: info.status,
+        league: info.league,
+        homeTeam: info.home_team || info.homeTeam,
+        awayTeam: info.away_team || info.awayTeam,
+        homeScore: parseInt(info.home_score) || 0,
+        awayScore: parseInt(info.away_score) || 0,
+      },
+      sources,
+      info: raw.info || '',
+    };
+  } catch (e) {
+    console.error('SportSRC detail error:', e);
     return null;
   }
 }
 
-export async function getManUtdUpcomingMatch(): Promise<Match | null> {
-  const matches = await getLiveScores();
-  const upcoming = matches.find(m => m.status === 'upcoming');
-  return upcoming || null;
+// === Get matches for a date ===
+export interface SportSrcMatch {
+  id: string;
+  leagueId: string;
+  leagueName: string;
+  home: string;
+  away: string;
+  homeId: string;
+  awayId: string;
+  status: string;
+  homeScore: number;
+  awayScore: number;
+  hasStream: boolean;
+  fotmobId?: number;
 }
 
-export async function getManUtdLiveMatch(): Promise<Match | null> {
-  const matches = await getLiveScores();
-  return matches.find(m => m.status === 'live') || null;
+export async function getMatchesForDate(date: string): Promise<SportSrcMatch[]> {
+  try {
+    const data = await apiGet({ type: 'matches', sport: 'football', date });
+    const matches: SportSrcMatch[] = [];
+    
+    for (const league of data.data || []) {
+      const leagueId = league.id || '';
+      const leagueName = league.name || '';
+      
+      for (const m of league.matches || []) {
+        const teams = m.teams || {};
+        const homeTeam = teams.home || {};
+        const awayTeam = teams.away || {};
+        
+        matches.push({
+          id: m.id,
+          leagueId,
+          leagueName,
+          home: homeTeam.name || '',
+          away: awayTeam.name || '',
+          homeId: homeTeam.id || '',
+          awayId: awayTeam.id || '',
+          status: m.status || '',
+          homeScore: parseInt(m.score?.current?.home) || 0,
+          awayScore: parseInt(m.score?.current?.away) || 0,
+          hasStream: m.has_stream || false,
+        });
+      }
+    }
+    
+    return matches;
+  } catch (e) {
+    console.error('SportSRC matches error:', e);
+    return [];
+  }
+}
+
+// === Get Man Utd match ===
+export async function findManUtdMatch(date: string): Promise<SportSrcMatch | null> {
+  const matches = await getMatchesForDate(date);
+  
+  return (
+    matches.find(m =>
+      m.home.toLowerCase().includes('manchester united') ||
+      m.away.toLowerCase().includes('manchester united')
+    ) || null
+  );
+}
+
+// === Channel list (all available stream channels) ===
+export interface Channel {
+  id: string;
+  name: string;
+  language: string;
+  embedUrl: string;
+  category?: string;
+}
+
+export async function getChannels(matchId: string): Promise<Channel[]> {
+  try {
+    const data = await apiGet({ type: 'channels', id: matchId });
+    return (data.data || []).map((c: any) => ({
+      id: c.id || c.name,
+      name: c.name || c.channel_name,
+      language: c.language || '',
+      embedUrl: c.embed_url || c.embedUrl || '',
+      category: c.category || '',
+    })).filter((c: Channel) => c.embedUrl);
+  } catch (e) {
+    console.error('SportSRC channels error:', e);
+    return [];
+  }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,17 +7,28 @@ export default {
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    borderRadius: {
+      none: '0',
+      sm: '2px',
+      DEFAULT: '2px',
+      md: '2px',
+      lg: '2px',
+      xl: '2px',
+      '2xl': '2px',
+      full: '9999px',
+    },
     extend: {
       colors: {
         united: {
           red: '#DA291C',
-          dark: '#0B0523',
           light: '#FBE122',
         },
+        bg: '#0a0a0a',
+        surface: '#111111',
       },
       backgroundColor: {
-        dark: '#0B0523',
-        darker: '#070112',
+        bg: '#0a0a0a',
+        surface: '#111111',
       },
     },
   },


### PR DESCRIPTION
## Summary

Video streaming integration using SportSRC API V2.

### What changed

**New: `src/lib/sportsrc.ts`**
- Full SportSRC API V2 integration
- `getMatchDetail()`: match info + stream sources with `embedUrl`
- `getMatchesForDate()`: all matches with team names, scores, `has_stream` flag
- `findManUtdMatch()`: find Man Utd match by date
- `getChannels()`: full channel list (623 channels)
- API key: `017f673f017dd588bc5b191cdfa9eb5b` (Basic plan, 10K/day)

**New: Watch tab on match detail page**
- Fourth tab alongside Events | Stats | Shot Map
- Auto-looks up SportSRC match from FotMob match (team name + date cross-reference)
- Shows iframe embed when `embedUrl` available (via `embed.streamapi.cc`)
- Stream source info (HD badge, language)
- Placeholder when stream not yet available
- Link to sport99.live for external viewing

**Updated: API route**
- `/api/matches?matchId=` now returns `{ match, stream, sportSrcId }` in one call
- Cross-references FotMob → SportSRC by team name + date
- 60s cache

**Note on streaming**
- SportSRC provides embed URLs from `embed.streamapi.cc`
- Streams typically appear closer to kickoff
- Basic plan supports detail + channels endpoints

### To test

```bash
cd code/glory-glory
cp .env.local.example .env.local
# Add SPORTSRC_API_KEY=017f673f017dd588bc5b191cdfa9eb5b
npm run dev
# Visit a match with stream available
```

Closes #5
